### PR TITLE
Expand platform support, migrate tests to Swift Testing, improve docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Build ShowcaseDependency (static analysis)
         run: swift build --target ShowcaseDependency
+
+      - name: Test Implicits for iOS
+        run: swift test --filter ImplicitsTests --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios14.0-simulator

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,11 @@ import PackageDescription
 let package = Package(
   name: "implicits",
   platforms: [
-    .macOS(.v13),
+    .macOS(.v11),
+    .iOS(.v14),
+    .watchOS(.v7),
+    .tvOS(.v14),
+    .visionOS(.v1),
   ],
   products: [
     .library(name: "Implicits", targets: ["Implicits"]),

--- a/Sources/ImplicitsTool/SupportFileBuilder.swift
+++ b/Sources/ImplicitsTool/SupportFileBuilder.swift
@@ -195,7 +195,7 @@ private struct ImportsIndex {
 /// `Bool` -> `bool`, `Foo.Bar` -> `fooBar`,
 /// `(Int32) -> Void` -> `int32Void`
 fileprivate func parameterNameFromType(_ type: String) -> String {
-  type.split(separator: #/\W+/#).enumerated()
+  type.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).enumerated()
     .map { index, s in
       s.mapFirstLetter { index > 0 ? $0.uppercased() : $0.lowercased() }
     }

--- a/Sources/TestResources/TestSupport.swift
+++ b/Sources/TestResources/TestSupport.swift
@@ -20,7 +20,7 @@ public final class TestSupport {
   public static func pathToSourceFile(_ name: String) -> String {
     var currentURL = URL(fileURLWithPath: #filePath)
     currentURL.deleteLastPathComponent()
-    currentURL.append(path: "test_data", directoryHint: .isDirectory)
+    currentURL.appendPathComponent("test_data")
     currentURL.appendPathComponent(name)
     return currentURL.path
   }

--- a/Sources/implicits-tool-spm-plugin/entry.swift
+++ b/Sources/implicits-tool-spm-plugin/entry.swift
@@ -70,13 +70,43 @@ extension StaticAnalysis {
       },
       modulename: modulename,
       dependencies: dependencies.map {
-        try FileReader(url: $0).withStream {
-          try ImplicitModuleInterface(from: &$0)
-        }
+        try readDependencyInterface(at: $0)
       },
       compilationConditions: .unknown,
       enableExporting: enableExporting
     )
+  }
+
+  private static func readDependencyInterface(at url: URL) throws -> ImplicitModuleInterface {
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw MissingInterfaceError(path: url.path)
+    }
+    return try FileReader(url: url).withStream {
+      try ImplicitModuleInterface(from: &$0)
+    }
+  }
+}
+
+struct MissingInterfaceError: CustomStringConvertible, Error {
+  var path: String
+
+  var description: String {
+    let moduleName = URL(fileURLWithPath: path)
+      .deletingPathExtension().lastPathComponent
+    return """
+    Missing implicit interface file for module '\(moduleName)'.
+
+    This usually means the module depends on Implicits but doesn't have \
+    the analysis plugin enabled. Add to your Package.swift:
+
+      .target(
+        name: "\(moduleName)",
+        dependencies: [...],
+        plugins: [.plugin(name: "ImplicitsAnalysisPlugin", package: "implicits")]
+      )
+
+    All modules in the dependency chain that use Implicits must have the plugin enabled.
+    """
   }
 }
 

--- a/Tests/ImplicitsTests/ImplicitConcurrencyTests.swift
+++ b/Tests/ImplicitsTests/ImplicitConcurrencyTests.swift
@@ -1,11 +1,11 @@
 // Copyright 2024 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 @_spi(Unsafe) internal import Implicits
 
-final class ImplicitConcurrencyTests: XCTestCase {
-  func testRetrievingInDifferentContext() async {
+struct ImplicitConcurrencyTests {
+  @Test func retrievingInDifferentContext() async {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -15,19 +15,19 @@ final class ImplicitConcurrencyTests: XCTestCase {
     let actor = SomeActor()
     let retrieved = await actor.testActorImplicit(scope)
 
-    XCTAssertEqual(retrieved, 1)
+    #expect(retrieved == 1)
   }
 
-  func testCreateRootScopeInActor() async {
+  @Test func createRootScopeInActor() async {
     let actor = SomeActor()
     let retrieved = await actor.createRootScope(id: 42)
 
-    XCTAssertEqual(retrieved, 42)
+    #expect(retrieved == 42)
   }
 
-  func testCreateRootScopeInMainActor() async {
+  @Test func createRootScopeInMainActor() async {
     let retrieved = await testMainActor(id: 81)
-    XCTAssertEqual(retrieved, 81)
+    #expect(retrieved == 81)
   }
 }
 
@@ -57,7 +57,7 @@ private func syncContext(_ scope: ImplicitScope) {
   @Implicit(\.id)
   var got
 
-  XCTAssertEqual(got, -1)
+  #expect(got == -1)
 }
 
 private func asyncGetId(_ scope: ImplicitScope) async -> Int {

--- a/Tests/ImplicitsTests/WithScopeTests.swift
+++ b/Tests/ImplicitsTests/WithScopeTests.swift
@@ -1,9 +1,9 @@
-import XCTest
+import Testing
 
 @_spi(Unsafe) internal import Implicits
 
-final class WithScopeTests: XCTestCase {
-  func testWithScope() {
+struct WithScopeTests {
+  @Test func scopeBasics() {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -13,7 +13,7 @@ final class WithScopeTests: XCTestCase {
     withScope { scope in
       @Implicit(\.id)
       var value = 200
-      XCTAssertEqual(value, 200)
+      #expect(value == 200)
 
       do {
         let scope = scope.nested()
@@ -21,16 +21,16 @@ final class WithScopeTests: XCTestCase {
 
         @Implicit(\.id)
         var value = 300
-        XCTAssertEqual(value, 300)
+        #expect(value == 300)
       }
 
-      XCTAssertEqual(value, 200)
+      #expect(value == 200)
     }
 
-    XCTAssertEqual(value, 42)
+    #expect(value == 42)
   }
 
-  func testWithScopeThrows() {
+  @Test func scopeThrows() {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -41,16 +41,16 @@ final class WithScopeTests: XCTestCase {
       try withScope { _ in
         @Implicit(\.id)
         var value = 300
-        XCTAssertEqual(value, 300)
+        #expect(value == 300)
         throw TestError()
       }
-      XCTFail("Should have thrown")
+      Issue.record("Should have thrown")
     } catch {
-      XCTAssertEqual(value, 42)
+      #expect(value == 42)
     }
   }
 
-  func testWithScopeNesting() {
+  @Test func scopeNesting() {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -65,35 +65,35 @@ final class WithScopeTests: XCTestCase {
       var inheritedId: Int
       @Implicit(\.launchID)
       var inheritedLaunchID: Int
-      XCTAssertEqual(inheritedId, 42)
-      XCTAssertEqual(inheritedLaunchID, 999)
+      #expect(inheritedId == 42)
+      #expect(inheritedLaunchID == 999)
 
       @Implicit(\.id)
       var overriddenId = 100
-      XCTAssertEqual(overriddenId, 100)
+      #expect(overriddenId == 100)
 
       @Implicit(\.launchID)
       var unchangedLaunchID: Int
-      XCTAssertEqual(unchangedLaunchID, 999)
+      #expect(unchangedLaunchID == 999)
     }
 
-    XCTAssertEqual(id, 42)
-    XCTAssertEqual(launchID, 999)
+    #expect(id == 42)
+    #expect(launchID == 999)
 
     do {
       try withScope(nesting: scope) { _ in
         @Implicit(\.id)
         var value = 300
-        XCTAssertEqual(value, 300)
+        #expect(value == 300)
         throw TestError()
       }
-      XCTFail("Should have thrown")
+      Issue.record("Should have thrown")
     } catch {
-      XCTAssertEqual(id, 42)
+      #expect(id == 42)
     }
   }
 
-  func testWithScopeWithBag() {
+  @Test func scopeWithBag() {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -107,16 +107,16 @@ final class WithScopeTests: XCTestCase {
       withScope(with: implicits) { _ in
         @Implicit(\.id)
         var inheritedValue: Int
-        XCTAssertEqual(inheritedValue, 42)
+        #expect(inheritedValue == 42)
 
         @Implicit(\.id)
         var overriddenValue = 100
-        XCTAssertEqual(overriddenValue, 100)
+        #expect(overriddenValue == 100)
       }
     }
     closure()
 
-    XCTAssertEqual(id, 42)
+    #expect(id == 42)
 
     do {
       let closure = {
@@ -126,18 +126,18 @@ final class WithScopeTests: XCTestCase {
         try withScope(with: implicits) { _ in
           @Implicit(\.id)
           var value = 300
-          XCTAssertEqual(value, 300)
+          #expect(value == 300)
           throw TestError()
         }
       }
       try closure()
-      XCTFail("Should have thrown")
+      Issue.record("Should have thrown")
     } catch {
-      XCTAssertEqual(id, 42)
+      #expect(id == 42)
     }
   }
 
-  func testWithScopeWithStoredBag() {
+  @Test func scopeWithStoredBag() {
     let scope = ImplicitScope()
     defer { scope.end() }
 
@@ -152,12 +152,12 @@ final class WithScopeTests: XCTestCase {
     )
 
     service.doWork { inheritedId, inheritedLaunchID in
-      XCTAssertEqual(inheritedId, 42)
-      XCTAssertEqual(inheritedLaunchID, 999)
+      #expect(inheritedId == 42)
+      #expect(inheritedLaunchID == 999)
     }
 
-    XCTAssertEqual(id, 42)
-    XCTAssertEqual(launchID, 999)
+    #expect(id == 42)
+    #expect(launchID == 999)
   }
 }
 

--- a/Tests/ImplicitsToolTests/AutomatonTests.swift
+++ b/Tests/ImplicitsToolTests/AutomatonTests.swift
@@ -1,13 +1,13 @@
 // Copyright 2024 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 import ImplicitsTool
 
-fileprivate typealias TestAutomaton = Automaton<Character, Int>
+private typealias TestAutomaton = Automaton<Character, Int>
 
-final class AutomatonTests: XCTestCase {
-  func testExact() {
+struct AutomatonTests {
+  @Test func exact() {
     var me = TestAutomaton()
     me.addPattern(.exact("a"), value: 1)
     me.addPattern(.exact("b"), value: 2)
@@ -19,7 +19,7 @@ final class AutomatonTests: XCTestCase {
     me.check("d", expected: [])
   }
 
-  func testSequence() {
+  @Test func sequence() {
     var me = TestAutomaton()
     me.addPattern(["a", "b", "c"], value: 1)
     me.addPattern(["a", "b"], value: 2)
@@ -30,7 +30,7 @@ final class AutomatonTests: XCTestCase {
     me.check("a1b", expected: [])
   }
 
-  func testOptional() {
+  @Test func optional() {
     var me = TestAutomaton()
     me.addPattern(["a", .optional("b"), "c"], value: 1)
     me.addPattern(["a", "c"], value: 2)
@@ -41,7 +41,7 @@ final class AutomatonTests: XCTestCase {
     me.check("abcd", expected: [])
   }
 
-  func testNested() {
+  @Test func nested() {
     var me = TestAutomaton()
     // 1: a(bc)?d
     me.addPattern(["a", .optional(["b", "c"]), "d"], value: 1)
@@ -57,7 +57,7 @@ final class AutomatonTests: XCTestCase {
     me.check("abcdef", expected: [])
   }
 
-  func testManyOptionalsDoesntCauseExponentialGrowth() {
+  @Test func manyOptionalsDoesntCauseExponentialGrowth() {
     let alphabet = "abcdefghijklmnopqrstuvwxyz"
     var me = TestAutomaton()
     me.addPattern(
@@ -80,7 +80,7 @@ final class AutomatonTests: XCTestCase {
     me.check("a" + alphabet, expected: [])
   }
 
-  func testZeroOrMore() {
+  @Test func zeroOrMore() {
     var me = TestAutomaton()
     me.addPattern([.zeroOrMore("a")], value: 1)
     me.addPattern(["b", .zeroOrMore("c"), "d"], value: 2)
@@ -95,7 +95,7 @@ final class AutomatonTests: XCTestCase {
     me.check("bccccd", expected: [2])
   }
 
-  func testMixed() {
+  @Test func mixed() {
     var me = TestAutomaton()
     me.addPattern(["a", .zeroOrMore("b"), "c"], value: 1)
     me.addPattern(["a", .zeroOrMore("b"), "c", "d"], value: 2)
@@ -112,10 +112,7 @@ final class AutomatonTests: XCTestCase {
 
 extension TestAutomaton {
   func check(_ input: String, expected: [Int]) {
-    XCTAssertEqual(
-      Set(match(input)),
-      Set(expected)
-    )
+    #expect(Set(match(input)) == Set(expected))
   }
 }
 

--- a/Tests/ImplicitsToolTests/IfConfigTests.swift
+++ b/Tests/ImplicitsToolTests/IfConfigTests.swift
@@ -1,22 +1,22 @@
 // Copyright 2025 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 @_spi(Testing)
 import ImplicitsTool
 import SwiftParser
 import SwiftSyntax
 
-final class IfConfigTests: XCTestCase {
-  func testConditionEvaluator() throws {
+struct IfConfigTests {
+  @Test func conditionEvaluator() throws {
     func check(_ e: String, _ expected: Bool?) {
       var parser = Parser(e)
       let e = ExprSyntax.parse(from: &parser)
       let res = evaluateCondition(
         e, config: .enabled(["A", "B", "C"])
       )
-      XCTAssertEqual(
-        res, expected,
+      #expect(
+        res == expected,
         "Expected \(e) to be \(expected.descr), but got \(res.descr)"
       )
     }
@@ -55,15 +55,14 @@ final class IfConfigTests: XCTestCase {
     check("A = B", nil)
   }
 
-  func testIfConfig() throws {
+  @Test func ifConfig() throws {
     func check(_ e: String, _ expected: String) {
       let syntax = Syntax(Parser.parse(source: e))
       let removed = removingInactiveIfConfig(
         syntax, config: .enabled(["A", "B", "C"])
       ).description
-      XCTAssertEqual(
-        removed.trim(\.isWhitespace),
-        expected.trim(\.isWhitespace),
+      #expect(
+        removed.trim(\.isWhitespace) == expected.trim(\.isWhitespace),
         "Expected \n\(e) to reduce into \n\(expected), but got \n\(removed)"
       )
     }

--- a/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
+++ b/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
@@ -1,6 +1,6 @@
 // Copyright 2023 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 import ImplicitsMacros
 import SwiftSyntaxMacros
@@ -10,8 +10,8 @@ private let testMacros: [String: Macro.Type] = [
   "implicits": ImplicitMacro.self,
 ]
 
-final class ImplicitMacroTests: XCTestCase {
-  func testImplicitMacro() throws {
+struct ImplicitMacroTests {
+  @Test func implicitMacro() throws {
     assertMacroExpansion(
       """
       let c = { [implictis = #implicits] in 42 }

--- a/Tests/ImplicitsToolTests/ImplicitsToolMacrosTests.swift
+++ b/Tests/ImplicitsToolTests/ImplicitsToolMacrosTests.swift
@@ -1,6 +1,6 @@
 // Copyright 2023 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 import ImplicitsToolMacros
 import SwiftSyntaxMacros
@@ -10,8 +10,8 @@ private let testMacros: [String: Macro.Type] = [
   "GeneralVisitorMacro": GeneralVisitorMacro.self,
 ]
 
-final class GeneralVisitorMacroTests: XCTestCase {
-  func testGeneralVisitorFailOnClass() throws {
+struct GeneralVisitorMacroTests {
+  @Test func generalVisitorFailOnClass() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -25,7 +25,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorFailOnStructWithNoGeneric() throws {
+  @Test func generalVisitorFailOnStructWithNoGeneric() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -39,7 +39,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorFailOnStructWithMoreThanOneGeneric() throws {
+  @Test func generalVisitorFailOnStructWithMoreThanOneGeneric() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -53,7 +53,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnEmptyStructWithOneGeneric() throws {
+  @Test func generalVisitorSuccessOnEmptyStructWithOneGeneric() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -82,7 +82,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnEmptyStructWithOneGenericAndDifferentName() throws {
+  @Test func generalVisitorSuccessOnEmptyStructWithOneGenericAndDifferentName() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -111,7 +111,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithOneGenericAndNoVisitors() throws {
+  @Test func generalVisitorSuccessOnStructWithOneGenericAndNoVisitors() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -162,7 +162,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithOneGenericAndOneVisitor() throws {
+  @Test func generalVisitorSuccessOnStructWithOneGenericAndOneVisitor() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -224,7 +224,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithOneGenericAndTwoSameVisitors() throws {
+  @Test func generalVisitorSuccessOnStructWithOneGenericAndTwoSameVisitors() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -266,7 +266,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithOneGenericAndOneRandomVariable() throws {
+  @Test func generalVisitorSuccessOnStructWithOneGenericAndOneRandomVariable() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -315,7 +315,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithDifferentlyNamedGeneric() throws {
+  @Test func generalVisitorSuccessOnStructWithDifferentlyNamedGeneric() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -395,7 +395,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorSuccessOnStructWithDifferentlyNamedVisitorAlias() throws {
+  @Test func generalVisitorSuccessOnStructWithDifferentlyNamedVisitorAlias() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro
@@ -475,7 +475,7 @@ final class GeneralVisitorMacroTests: XCTestCase {
     )
   }
 
-  func testGeneralVisitorCorrectForm() throws {
+  @Test func generalVisitorCorrectForm() throws {
     assertMacroExpansion(
       """
       @GeneralVisitorMacro

--- a/Tests/ImplicitsToolTests/PublicInterfaceSerializationTests.swift
+++ b/Tests/ImplicitsToolTests/PublicInterfaceSerializationTests.swift
@@ -1,25 +1,25 @@
 // Copyright 2024 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 import ImplicitsTool
 
-final class PublicInterfaceSerializationTests: XCTestCase {
-  func testSymbolSerialization() {
+struct PublicInterfaceSerializationTests {
+  @Test func symbolSerialization() {
     check(initSymbol)
     check(staticSymbol)
     check(memberSymbol)
   }
 
-  func testInterfaceSerialization() {
+  @Test func interfaceSerialization() {
     check(interface)
   }
 
-  func testInterface2Serialization() {
+  @Test func interface2Serialization() {
     check(interface2)
   }
 
-  func testEmptyInterfaceSerialization() {
+  @Test func emptyInterfaceSerialization() {
     check(ImplicitModuleInterface(
       module: "EmptyModule", symbols: [], testableSymbols: [],
       definedKeypathKeys: [],

--- a/Tests/ImplicitsToolTests/SerializationTests.swift
+++ b/Tests/ImplicitsToolTests/SerializationTests.swift
@@ -1,11 +1,12 @@
 // Copyright 2024 Yandex LLC. All rights reserved.
 
-import XCTest
+import Foundation
+import Testing
 
 import ImplicitsTool
 
-final class SerializationTests: XCTestCase {
-  func testIntegers() {
+struct SerializationTests {
+  @Test func integers() {
     check(UInt8.min)
     check(UInt8(13))
     check(UInt8.max)
@@ -17,13 +18,13 @@ final class SerializationTests: XCTestCase {
     check(Int32(-1_300_000))
   }
 
-  func testStrings() {
+  @Test func strings() {
     check("")
     check("Hello, world!")
     check("🚀")
   }
 
-  func testArrays() {
+  @Test func arrays() {
     check([Int32]())
     check([Int32(-5), 2, 3])
     check([[[Int32]]]())
@@ -32,7 +33,7 @@ final class SerializationTests: XCTestCase {
     check([["a", "b"], ["c", "d"], ["e", "f"]])
   }
 
-  func testInvalidDataError() throws {
+  @Test func invalidDataError() throws {
     enum Foo: UInt8, Serializable {
       case a = 1, b = 2
     }
@@ -41,14 +42,16 @@ final class SerializationTests: XCTestCase {
     }
     let value = Foo.b
     let bytes = try value.testSerialize()
-    XCTAssertThrowsError(try Bar.testDeserialize(from: bytes))
+    #expect(throws: SerializationError.self) {
+      try Bar.testDeserialize(from: bytes)
+    }
   }
 
-  func testUntrivialTypes() {
+  @Test func untrivialTypes() {
     check(Parent(bar: 42))
     let child = Child(bar: 0, baz: 0)
     let child2 = Child(bar: 0, baz: 1)
-    XCTAssertNotEqual(child, child2)
+    #expect(child != child2)
     check([Pointer(child), Pointer(child2)])
   }
 

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -1,76 +1,76 @@
 // Copyright 2023 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
-final class StaticAnalysisTests: XCTestCase {
-  func testSyntaxStructure() {
+struct StaticAnalysisTests {
+  @Test func syntaxStructure() {
     verify(file: "syntax_structure.swift")
   }
 
-  func testBasicGraph() {
+  @Test func basicGraph() {
     verify(file: "graph_basic.swift")
   }
 
-  func testNestedScopes() {
+  @Test func nestedScopes() {
     verify(file: "nested_scope.swift")
   }
 
-  func testRecursion() {
+  @Test func recursion() {
     verify(file: "graph_recursion.swift")
   }
 
-  func testObjectScope() {
+  @Test func objectScope() {
     verify(file: "object_scope.swift")
   }
 
-  func testSymbolResolution() {
+  @Test func symbolResolution() {
     verify(file: "symbol_resolution.swift")
   }
 
-  func testImplicitBag() {
+  @Test func implicitBag() {
     verify(file: "implicit_bag.swift")
   }
 
-  func testStoredImplicitBag() {
+  @Test func storedImplicitBag() {
     verify(file: "stored_implicit_bag.swift")
   }
 
-  func testImplicitScopeOrder() {
+  @Test func implicitScopeOrder() {
     verify(file: "implicit_scope_order.swift")
   }
 
-  func testKeyResolving() {
+  @Test func keyResolving() {
     verify(file: "key_resolving.swift")
   }
 
-  func testExpressions() {
+  @Test func expressions() {
     verify(file: "expressions.swift")
   }
 
-  func testImplicitMap() {
+  @Test func implicitMap() {
     verify(file: "implicit_map.swift")
   }
 
-  func testWithScope() {
+  @Test func withScope() {
     verify(file: "with_scope.swift")
   }
 
-  func testGeneratedInit() {
+  @Test func generatedInit() {
     verify(file: "generated_init.swift")
   }
 
-  func testTypeResolution() {
+  @Test func typeResolution() {
     verify(file: "type_resolution.swift")
   }
 
-  func testMultipleFileResolution() {
+  @Test func multipleFileResolution() {
     verify(files: [
       "multiple_file_resolution_f1.swift",
       "multiple_file_resolution_f2.swift",
     ])
   }
 
-  func testUsingImplicitInterface() {
+  @Test func usingImplicitInterface() {
     verify(
       files: [
         "using_implicit_interface.swift",
@@ -79,7 +79,7 @@ final class StaticAnalysisTests: XCTestCase {
     )
   }
 
-  func testUsingTestableImplicitInterface() {
+  @Test func usingTestableImplicitInterface() {
     verify(
       files: [
         "using_testable_implicit_interface.swift",
@@ -88,11 +88,11 @@ final class StaticAnalysisTests: XCTestCase {
     )
   }
 
-  func testExporting() {
+  @Test func exporting() {
     verify(file: "exporting.swift", enableExporting: true)
   }
 
-  func testSupportFile() {
+  @Test func supportFile() {
     verify(
       files: ["support_file.swift"],
       enableExporting: true,

--- a/Tests/ImplicitsToolTests/TypeModelCanonicalDesciptionTests.swift
+++ b/Tests/ImplicitsToolTests/TypeModelCanonicalDesciptionTests.swift
@@ -1,45 +1,45 @@
 // Copyright 2024 Yandex LLC. All rights reserved.
 
-import XCTest
+import Testing
 
 import ImplicitsTool
 import SwiftParser
 import SwiftSyntax
 
-final class TypeModelCanonicalDesciptionTests: XCTestCase {
-  func testSimple() {
+struct TypeModelCanonicalDesciptionTests {
+  @Test func simple() {
     check("Foo")
     check(" Foo  ", "Foo")
   }
 
-  func testGeneric() {
+  @Test func generic() {
     check("Foo<Bar>")
     check(" Foo< Bar , Baz > ", "Foo<Bar, Baz>")
   }
 
-  func testOptional() {
+  @Test func optional() {
     check("Foo?")
   }
 
-  func testUnwrappedOptional() {
+  @Test func unwrappedOptional() {
     check("Foo!")
   }
 
-  func testTuple() {
+  @Test func tuple() {
     check("(Foo, Bar)")
     check("(Foo,Bar)", "(Foo, Bar)")
     check("(foo:Foo,  bar  :  Bar  )", "(foo: Foo, bar: Bar)")
   }
 
-  func testMember() {
+  @Test func member() {
     check("Foo.Bar")
   }
 
-  func testArray() {
+  @Test func array() {
     check("[Foo]")
   }
 
-  func testAttributed() {
+  @Test func attributed() {
     check("@foo Bar")
     check("@foo @bar Baz")
     check("@foo(bar: baz) Qux")
@@ -52,54 +52,54 @@ final class TypeModelCanonicalDesciptionTests: XCTestCase {
     check("  __shared   Bar ", "__shared Bar")
   }
 
-  func testClassRestriction() {
+  @Test func classRestriction() {
     // Only valid in protocol restrictions, which SyntaxTree doesn't support yet
   }
 
-  func testComposition() {
+  @Test func composition() {
     check("Foo & Bar & Baz")
   }
 
-  func testDictionary() {
+  @Test func dictionary() {
     check("[Foo: Bar]")
     check("[Foo:Bar]", "[Foo: Bar]")
     check("[Foo : Bar]", "[Foo: Bar]")
     check("[  Foo  :  Bar  ]", "[Foo: Bar]")
   }
 
-  func testFunction() {
+  @Test func function() {
     check("(Foo) -> Bar")
     check("(Foo)->Bar", "(Foo) -> Bar")
     check("( _ foo : Foo, _ bar:Bar) -> Baz", "(_ foo: Foo, _ bar: Bar) -> Baz")
     check("(@escaping () throws -> Foo) async -> Bar")
   }
 
-  func testMetatype() {
+  @Test func metatype() {
     check("Foo.Type")
     check("Foo.Protocol")
   }
 
-  func testNamedOpaqueReturn() {
+  @Test func namedOpaqueReturn() {
     check("<each Foo: Bar> Foo")
   }
 
-  func testPackElement() {
+  @Test func packElement() {
     check("each Foo")
   }
 
-  func testPackExpansion() {
+  @Test func packExpansion() {
     check("repeat Foo")
   }
 
-  func testSomeOrAny() {
+  @Test func someOrAny() {
     check("some Foo")
   }
 
-  func testSuppressed() {
+  @Test func suppressed() {
     check("~Foo")
   }
 
-  func testNested() {
+  @Test func nested() {
     check("@escaping (Foo<[(dict: [Bar: P1 & P2], Baz.Qux!?)]>) -> Void")
   }
 }
@@ -138,7 +138,8 @@ func check(
   )
   let tl = sxtTree.first
   guard let got = tl.flatMap({ policy.extract($0)?.description }) else {
-    return XCTFail("Failed to extract type model")
+    Issue.record("Failed to extract type model")
+    return
   }
-  XCTAssertEqual(got, output)
+  #expect(got == output)
 }


### PR DESCRIPTION
## Summary

- Expand platform support: iOS 14+, watchOS 7+, tvOS 14+, visionOS 1+, macOS 11+
- Migrate all tests from XCTest to Swift Testing
- Improve README documentation with SPM plugin integration section
- Add better diagnostics for missing intermediate module interfaces

## Changes

### Platform Support
- Add iOS 14, watchOS 7, tvOS 14, visionOS 1 to Package.swift
- Lower macOS minimum from 13 to 11
- Add iOS simulator test to CI workflow
- Replace regex with closure-based split for iOS compatibility
- Use older URL API for compatibility with macOS 11

### Documentation
- Rewrite README examples to be more generic
- Add SPM Plugin Integration section explaining cross-module analysis
- Add diagram showing how .implicitinterface files enable cross-module verification
- Document requirement for all intermediate modules to have plugin enabled

### Diagnostics
- Add `MissingInterfaceError` with helpful message when intermediate module is missing the plugin

### Tests
- Migrate all tests from XCTest to Swift Testing framework

## Test plan
- [ ] CI passes (swift build, swift test, iOS test)
- [ ] Verify README renders correctly on GitHub