### PR TITLE
Add named implicits wrappers (withFooImplicits pattern)

### DIFF
--- a/Sources/ImplicitsTool/Constants.swift
+++ b/Sources/ImplicitsTool/Constants.swift
@@ -33,4 +33,9 @@ enum ImplicitKeyword {
   static let keysEnumName = "ImplicitsKeys"
   static let annotationsConstructor = "_annotationsInit"
   static let anonClosureNamePrefix = "_anonClosure"
+
+  enum ClosureWrapper {
+    static let prefix = "with"
+    static let suffix = "Implicits"
+  }
 }

--- a/Sources/ImplicitsTool/ImplicitModuleInterface.swift
+++ b/Sources/ImplicitsTool/ImplicitModuleInterface.swift
@@ -5,11 +5,11 @@ public struct ImplicitModuleInterface: Equatable, Sendable {
 
   public struct Symbol: Equatable, Sendable {
     public var info: ExternalSymbol
-    public var requrements: [ImplicitKey]?
+    public var requirements: [ImplicitKey]?
 
-    public init(info: ExternalSymbol, requrements: [ImplicitKey]?) {
+    public init(info: ExternalSymbol, requirements: [ImplicitKey]?) {
       self.info = info
-      self.requrements = requrements
+      self.requirements = requirements
     }
   }
 
@@ -76,14 +76,14 @@ extension ImplicitModuleInterface.Symbol: Serializable {
   public init(
     from stream: inout some InputByteStream
   ) throws(SerializationError) {
-    try self.init(info: .init(from: &stream), requrements: .init(from: &stream))
+    try self.init(info: .init(from: &stream), requirements: .init(from: &stream))
   }
 
   public func serialize(
     to buffer: inout some OutputByteStream
   ) throws(SerializationError) {
     try info.serialize(to: &buffer)
-    try requrements.serialize(to: &buffer)
+    try requirements.serialize(to: &buffer)
   }
 }
 

--- a/Sources/ImplicitsTool/SemaTree.swift
+++ b/Sources/ImplicitsTool/SemaTree.swift
@@ -74,6 +74,7 @@ enum SemaTree<Syntax> {
     case implicitScopeBegin(nested: Bool, withBag: Bool)
     case implicitScopeEnd
     case withScope(nested: Bool, withBag: Bool, body: [CodeBlockItem])
+    case withNamedImplicits(wrapperName: String, closureParamCount: Int, body: [CodeBlockItem])
     case implicitMap(from: ImplicitKey, to: ImplicitKey)
     case implicit(Implicit)
   }
@@ -248,6 +249,12 @@ extension SemaTree.CodeBlockItemNode {
       .implicit(implicit)
     case let .withScope(nested: nested, withBag: withBag, body: body):
       .withScope(nested: nested, withBag: withBag, body: body.map { $0.mapSyntax(transform) })
+    case let .withNamedImplicits(wrapperName: name, closureParamCount: count, body: body):
+      .withNamedImplicits(
+        wrapperName: name,
+        closureParamCount: count,
+        body: body.map { $0.mapSyntax(transform) }
+      )
     case let .implicitMap(from: from, to: to):
       .implicitMap(from: from, to: to)
     }

--- a/Sources/ImplicitsTool/StaticAnalysis.swift
+++ b/Sources/ImplicitsTool/StaticAnalysis.swift
@@ -81,9 +81,9 @@ public enum StaticAnalysis {
       sema: Array(zip(syntaxTrees, semaTrees)),
       diagnostics: &diagnostics,
       dependencies: dependencies.flatMap { $0.symbols.map { symbol in
-        (symbol.info.mapSyntax { .external($0) }, symbol.requrements)
+        (symbol.info.mapSyntax { .external($0) }, symbol.requirements)
       }} + dependencies.flatMap { $0.testableSymbols.map { symbol in
-        (symbol.info.mapSyntax { .external($0) }, symbol.requrements)
+        (symbol.info.mapSyntax { .external($0) }, symbol.requirements)
       }}
     )
     let checked = reqGraph.resolveRequirements(
@@ -106,13 +106,13 @@ public enum StaticAnalysis {
 
     let externalSymbols = publicFunctions.compactMap {
       $0.1.moreOrEqualVisible(than: .package) ? ImplicitModuleInterface.Symbol(
-        info: $0.0, requrements: externalFuncsWithImplicits[$0.0]
+        info: $0.0, requirements: externalFuncsWithImplicits[$0.0]
       ) : nil
     }
     let testableSymbols = publicFunctions.compactMap {
       $0.1.moreOrEqualVisible(than: .internal) &&
         $0.1.lessOrEqualVisible(than: .package) ? ImplicitModuleInterface.Symbol(
-          info: $0.0, requrements: testableFuncsWithImplicits[$0.0]
+          info: $0.0, requirements: testableFuncsWithImplicits[$0.0]
         ) : nil
     }
 
@@ -120,6 +120,7 @@ public enum StaticAnalysis {
       syntaxTrees: syntaxTrees, semaTrees: semaTrees,
       implicitFunctions: checked.implicitFunctions,
       bags: checked.bags,
+      namedImplicitsWrappers: checked.namedImplicitsWrappers,
       enableExporting: enableExporting,
       dependencies: dependencies,
       diagnostics: &diagnostics,

--- a/Sources/ImplicitsTool/SupportFile.swift
+++ b/Sources/ImplicitsTool/SupportFile.swift
@@ -17,12 +17,19 @@ public struct SupportFile {
     public var returnType: String?
   }
 
+  public struct NamedImplicitsWrapper {
+    public var wrapperName: String
+    public var closureParamCount: Int
+    public var requirements: [ImplicitKey]
+  }
+
   var keys: [Sema.ImplicitKeyDecl]
   var imports: [(Visibility, String, debugBlame: String)]
   var ifFalseImports: [(Visibility, String, debugBlame: String)]
   var functions: [(FuncSignature, [ImplicitParameter])]
   var ifFalseFunctions: [(FuncSignature, [ImplicitParameter])]
   var bags: [(name: String, requirements: [ImplicitKey])]
+  var namedImplicitsWrappers: [NamedImplicitsWrapper]
 }
 
 extension SupportFile {

--- a/Sources/TestResources/test_data/support_file.swift
+++ b/Sources/TestResources/test_data/support_file.swift
@@ -32,6 +32,20 @@ private func withBag(_: ImplicitScope) {
   }
 }
 
+private func withImplicits(_: ImplicitScope) {
+  _ = withSupportZeroImplicits { scope in
+    requires(scope)
+  }
+  _ = withSupportOneImplicits { (a: Int, scope) in
+    _ = a
+    requires(scope)
+  }
+  _ = withSupportTwoImplicits { (a: String, b: Bool, scope) in
+    _ = a; _ = b
+    requires(scope)
+  }
+}
+
 @_spi(Implicits)
 public func supportFileFunc(arg: Int, _: ImplicitScope) {
   @Implicit()

--- a/Sources/TestResources/test_data/support_file_snapshot.swift
+++ b/Sources/TestResources/test_data/support_file_snapshot.swift
@@ -28,8 +28,41 @@ internal func __implicit_bag_support_file_swift_28_22() -> Implicits {
   Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
 }
 
-internal func __implicit_bag_support_file_swift_48_19() -> Implicits {
+internal func __implicit_bag_support_file_swift_62_19() -> Implicits {
   Implicits()
+}
+
+internal func withSupportZeroImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(scope)
+  }
+}
+
+internal func withSupportOneImplicits<T, A1>(_ body: @escaping (A1, ImplicitScope) -> T) -> (A1) -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return { arg1 in
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(arg1, scope)
+  }
+}
+
+internal func withSupportTwoImplicits<T, A1, A2>(_ body: @escaping (A1, A2, ImplicitScope) -> T) -> (A1, A2) -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return { arg1, arg2 in
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(arg1, arg2, scope)
+  }
 }
 
 public func supportFileFunc(arg: Int, bool: @autoclosure () -> Bool, keyFromAnotherModule: @autoclosure () -> [String: [Int]], supportFileKey2: @autoclosure () -> [Int]) {

--- a/Sources/TestResources/test_data/with_named_implicits.swift
+++ b/Sources/TestResources/test_data/with_named_implicits.swift
@@ -1,0 +1,89 @@
+@_spi(Unsafe)
+import Implicits
+
+private func basicUsage() {
+  // expected-error@+1 {{Unresolved requirements: UInt16, UInt32, UInt8}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  let _: () -> Void = withZeroArgsImplicits { scope in
+    @Implicit var _: UInt8
+  }
+
+  let _: (Int) -> Void = withOneArgImplicits { (a: Int, scope) in
+    @Implicit var _: UInt16
+  }
+
+  let _: (String, Bool) -> Void = withTwoArgsImplicits { (a: String, b: Bool, scope) in
+    @Implicit var _: UInt32
+  }
+}
+
+private func nestedWrappers() {
+  // expected-error@+1 {{Unresolved requirements: Int16, Int8}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  _ = withOuterImplicits { scope in
+    @Implicit var _: Int8
+
+    _ = withInnerImplicits { (_: Int, scope) in
+      @Implicit var _: Int16
+    }
+  }
+}
+
+private func conditionalBranches() {
+  // expected-error@+1 {{Unresolved requirements: Int32, Int64}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  if Bool.random() {
+    _ = withBranchAImplicits { scope in
+      @Implicit var _: Int32
+    }
+  } else {
+    _ = withBranchBImplicits { (_: Int, scope) in
+      @Implicit var _: Int64
+    }
+  }
+}
+
+private func bagCapture() {
+  // expected-error@+1 {{Unresolved requirement: Float}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  let closure = { [implicits = namedImplicitsBag()] in
+    let scope = ImplicitScope(with: implicits)
+    defer { scope.end() }
+
+    _ = withBagImplicits { scope in
+      @Implicit var _: Float
+    }
+  }
+  closure()
+}
+
+private func missingScope() {
+  // expected-error@+1 {{Using implicits without 'ImplicitScope'}}
+  let _: () -> Void = withOrphanImplicits { scope in
+    @Implicit var _: Double
+  }
+}
+
+private func duplicateNames(_: ImplicitScope) {
+  // expected-note@+1 {{Previous wrapper here}}
+  _ = withDuplicateImplicits { scope in
+    @Implicit var _: UInt8
+  }
+
+  // expected-error@+1 {{Implicit closure wrappers must have unique names, 'withDuplicateImplicits' is already defined}}
+  _ = withDuplicateImplicits { scope in
+    @Implicit var _: Int8
+  }
+
+  _ = withDuplicateImplicits { scope in
+    @Implicit var _: Int16
+  }
+}

--- a/Sources/TestResources/test_data/with_named_implicits_stubs.swift
+++ b/Sources/TestResources/test_data/with_named_implicits_stubs.swift
@@ -1,0 +1,46 @@
+@_spi(Unsafe)
+import Implicits
+
+func withZeroArgsImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}
+
+func withOneArgImplicits<T, A1>(_ body: @escaping (A1, ImplicitScope) -> T) -> (A1) -> T {
+  { a1 in body(a1, ImplicitScope()) }
+}
+
+func withTwoArgsImplicits<T, A1, A2>(_ body: @escaping (A1, A2, ImplicitScope) -> T) -> (A1, A2) -> T {
+  { a1, a2 in body(a1, a2, ImplicitScope()) }
+}
+
+func withOuterImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}
+
+func withInnerImplicits<T, A1>(_ body: @escaping (A1, ImplicitScope) -> T) -> (A1) -> T {
+  { a1 in body(a1, ImplicitScope()) }
+}
+
+func withBranchAImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}
+
+func withBranchBImplicits<T, A1>(_ body: @escaping (A1, ImplicitScope) -> T) -> (A1) -> T {
+  { a1 in body(a1, ImplicitScope()) }
+}
+
+func withBagImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}
+
+func namedImplicitsBag() -> Implicits {
+  Implicits()
+}
+
+func withOrphanImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}
+
+func withDuplicateImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  { body(ImplicitScope()) }
+}

--- a/Tests/ImplicitsToolTests/PublicInterfaceSerializationTests.swift
+++ b/Tests/ImplicitsToolTests/PublicInterfaceSerializationTests.swift
@@ -61,7 +61,7 @@ private let interface2 = ImplicitModuleInterface(
         syntax: .init(file: "n_another_module.swift", line: 5, column: 1),
         file: "n_another_module.swift"
       ),
-      requrements: [.init(kind: .type, name: "AnotherModuleStruct")]
+      requirements: [.init(kind: .type, name: "AnotherModuleStruct")]
     ),
   ],
   testableSymbols: [],
@@ -87,7 +87,7 @@ private let initSymbol = ImplicitModuleInterface.Symbol(
     syntax: .init(file: "test.swift", line: 1, column: 2),
     file: "test.swift"
   ),
-  requrements: [.init(kind: .keyPath, name: "myType")]
+  requirements: [.init(kind: .keyPath, name: "myType")]
 )
 
 private let staticSymbol = ImplicitModuleInterface.Symbol(
@@ -103,7 +103,7 @@ private let staticSymbol = ImplicitModuleInterface.Symbol(
     syntax: .init(file: "test.swift", line: 1, column: 2),
     file: "test.swift"
   ),
-  requrements: nil
+  requirements: nil
 )
 
 private let memberSymbol = ImplicitModuleInterface.Symbol(
@@ -118,5 +118,5 @@ private let memberSymbol = ImplicitModuleInterface.Symbol(
     syntax: .init(file: "test.swift", line: 3, column: 4),
     file: "test.swift"
   ),
-  requrements: [.init(kind: .keyPath, name: "myType")]
+  requirements: [.init(kind: .keyPath, name: "myType")]
 )

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -55,6 +55,10 @@ struct StaticAnalysisTests {
     verify(file: "with_scope.swift")
   }
 
+  @Test func withNamedImplicits() {
+    verify(file: "with_named_implicits.swift")
+  }
+
   @Test func generatedInit() {
     verify(file: "generated_init.swift")
   }

--- a/Tests/ImplicitsToolTests/TestSupport.swift
+++ b/Tests/ImplicitsToolTests/TestSupport.swift
@@ -158,7 +158,7 @@ private func reportDiagnostic(_ kind: DiagnosticErrorKind, _ diag: Diagnostic, a
       fileID: file,
       filePath: file,
       line: diag.loc.line,
-      column: 0
+      column: 1
     )
   )
 }


### PR DESCRIPTION
## Summary

- Add closure wrapper functions that capture implicit dependencies at definition time
- Wrappers provide dependencies when the closure is invoked later
- Support for additional closure parameters (0 to N args before scope)

## Usage

```swift
// Zero additional params
withFooImplicits { scope in
    requires(scope)
}

// With additional params
withFooImplicits { (a: Int, b: String, scope) in
    _ = a; _ = b
    requires(scope)
}
```

## Generated code

```swift
func withFooImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
    let implicits = Implicits(unsafeKeys: ...)
    return {
        let scope = ImplicitScope(with: implicits)
        defer { scope.end() }
        return body(scope)
    }
}
```

Part of #5