### PR TITLE
Refactor CodeBlockStatement to use Expression and Statement enums

### DIFF
--- a/Sources/ImplicitsTool/GeneralVisitor.swift
+++ b/Sources/ImplicitsTool/GeneralVisitor.swift
@@ -36,6 +36,7 @@ struct GeneralVisitor<State>: @unchecked Sendable {
   var visitFunctionDecl: Visitor<FunctionDeclSyntax> = emptyVisitor()
   var visitInitializerDecl: Visitor<InitializerDeclSyntax> = emptyVisitor()
   var visitDeferStmt: Visitor<DeferStmtSyntax> = emptyVisitor()
+  var visitDoStmt: Visitor<DoStmtSyntax> = emptyVisitor()
   var visitClosureExpr: Visitor<ClosureExprSyntax> = emptyVisitor()
   var visitFunctionCallExpr: Visitor<FunctionCallExprSyntax> = emptyVisitor()
   var visitVariableDecl: Visitor<VariableDeclSyntax> = emptyVisitor()

--- a/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
@@ -620,7 +620,7 @@ extension SemaTreeBuilder.Context {
         return nil
       }
       return type
-    case .other, .macroExpansion:
+    case .other, .macroExpansion, .closure:
       diagnostics.diagnose(.unableToInferType, at: syntax)
       return nil
     }
@@ -793,7 +793,7 @@ extension SemaTreeBuilder.Context.VariableInfoForTypeInference {
         case .end, nil:
           return false
         }
-      case .declRef, .other, .memberAccessor, .macroExpansion:
+      case .declRef, .other, .memberAccessor, .macroExpansion, .closure:
         return false
       }
     }


### PR DESCRIPTION
## Summary
- Replace `.functionCall` and `.closureExpr` cases with `.expr(Expression)` in `CodeBlockStatement`
- Add `.closure` case to `Expression` enum to complete the expression types
- Replace `.deferStmt` and `.codeBlockItemList` with `.stmt(Statement)` for cleaner statement handling
- Add `Statement` enum with `.defer`, `.do`, and `.other` cases
- Add `DoStmt` struct to represent do-catch blocks with body and catch bodies
- Add `visitDoStmt` to `GeneralVisitor` for do-catch statement handling

This refactoring brings the syntax tree structure closer to SwiftSyntax and provides cleaner separation between declarations, expressions, and statements.

## Test plan
- [x] All 92 existing tests pass
- [x] Build succeeds for all targets