### PR TITLE
Update swift-syntax to 602.0.0 and enable prebuilts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
           xcode-version: latest-stable
 
       - name: Build
-        run: swift build -v
+        run: swift build -v --enable-experimental-prebuilts
 
       - name: Run tests
-        run: SWIFT_DETERMINISTIC_HASHING=1 swift test -v --parallel
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test -v --parallel --enable-experimental-prebuilts
 
       - name: Build Showcase (static analysis)
-        run: swift build --target Showcase
+        run: swift build --target Showcase --enable-experimental-prebuilts
 
       - name: Build ShowcaseDependency (static analysis)
-        run: swift build --target ShowcaseDependency
+        run: swift build --target ShowcaseDependency --enable-experimental-prebuilts
 
       - name: Test Implicits for iOS
-        run: swift test --filter ImplicitsTests --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios14.0-simulator
+        run: swift test --filter ImplicitsTests --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios14.0-simulator --enable-experimental-prebuilts

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "39f70d59a2d9d05328502b4543cc30ea25f368be9015a61c129ef5d34c4fffc9",
+  "originHash" : "1994c61710d52fe83cbc4d7008120b78c83a7bab74401a294a5a6a7b2f7afe75",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.6.1"),
-    .package(url: "https://github.com/apple/swift-syntax", from: "601.0.1"),
+    .package(url: "https://github.com/apple/swift-syntax", from: "602.0.0"),
   ],
   targets: [
     .target(

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -724,7 +724,7 @@ enum SemaTreeBuilder<
       }
     case let .member(members):
       members.forEach { visit(typeModel: $0, syntax: syntax, errors: &errors) }
-    case .attributed, .classRestriction, .array,
+    case .attributed, .classRestriction, .array, .inlineArray,
          .composition, .dictionary, .function, .metatype, .missing,
          .namedOpaqueReturn, .packElement, .packExpansion, .someOrAny,
          .suppressed:

--- a/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
@@ -738,7 +738,7 @@ extension SyntaxTree.TypeModel {
       return wrapped.componentsWithoutGenerics()
     case let .unwrappedOptional(wrapped):
       return wrapped.componentsWithoutGenerics()
-    case .tuple, .attributed, .classRestriction, .array,
+    case .tuple, .attributed, .classRestriction, .array, .inlineArray,
          .composition, .dictionary, .function, .metatype, .missing,
          .namedOpaqueReturn, .packElement, .packExpansion, .someOrAny,
          .suppressed:

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -274,6 +274,8 @@ public enum SyntaxTree<Syntax> {
     case member([TypeModel])
     /// `[T]`
     case array(TypeModel)
+    /// `[3 of T]` (InlineArray)
+    case inlineArray(count: TypeModel, element: TypeModel)
     /// `inout @Foo T`
     case attributed(specifiers: [String], [Attribute], TypeModel)
     /// `protocol P: class { ... }`
@@ -818,6 +820,8 @@ extension SyntaxTree.TypeModel {
       .member(v.map { $0.mapSyntax(t) })
     case let .array(v):
       .array(v.mapSyntax(t))
+    case let .inlineArray(count, element):
+      .inlineArray(count: count.mapSyntax(t), element: element.mapSyntax(t))
     case let .attributed(specifiers, attributes, type):
       .attributed(
         specifiers: specifiers,

--- a/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
@@ -526,6 +526,11 @@ extension TypeSyntax {
       parseIdentifierSyntax(
         t.name, t.genericArgumentClause, context: context
       )
+    case let .inlineArrayType(t):
+      .inlineArray(
+        count: t.count.argument.parsedType(context: context),
+        element: t.element.argument.parsedType(context: context)
+      )
     case let .implicitlyUnwrappedOptionalType(t):
       .unwrappedOptional(t.wrappedType.parsedType(context: context))
     case let .memberType(t):
@@ -803,14 +808,6 @@ extension AttributeSyntax.Arguments {
     switch self {
     case let .argumentList(labeled):
       labeled.parsedArguments(context: context)
-    case let .token(token):
-      .init([.init(
-        name: nil,
-        value: .init(
-          value: .reference(.identifier(token.trimmedDescription)),
-          syntax: token
-        )
-      )])
     default:
       nil
     }

--- a/Sources/ImplicitsTool/SyntaxTreeTypeModelCanonicalDescription.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeTypeModelCanonicalDescription.swift
@@ -56,6 +56,8 @@ extension SyntaxTree.TypeModel {
       member.map { $0.render(&policy) }.joined(separator: ".")
     case let .array(array):
       "[" + array.render(&policy) + "]"
+    case let .inlineArray(count, element):
+      "[" + count.render(&policy) + " of " + element.render(&policy) + "]"
     case let .dictionary(key, value):
       "[" + key.render(&policy) + ": " + value.render(&policy) + "]"
     case let .function(params, effects, returnType):

--- a/Sources/ImplicitsToolMacros/ImplicitsToolMacrosSupport.swift
+++ b/Sources/ImplicitsToolMacros/ImplicitsToolMacrosSupport.swift
@@ -29,19 +29,17 @@ extension DeclModifierSyntax {
   }
 }
 
-extension SwiftSyntax.ClosureShorthandParameterSyntax: Swift.ExpressibleByStringLiteral {
-  public init(stringLiteral value: String) {
-    self.init(name: TokenSyntax(stringLiteral: value))
-  }
-}
-
 extension ClosureSignatureSyntax.ParameterClause {
   static func simpleInput(
-    parameters: ClosureShorthandParameterSyntax...
+    parameters: String...
   ) -> Self {
     .simpleInput(
       ClosureShorthandParameterListSyntax(
-        itemsBuilder: { for param in parameters { param } }
+        itemsBuilder: {
+          for name in parameters {
+            ClosureShorthandParameterSyntax(name: .identifier(name))
+          }
+        }
       )
     )
   }


### PR DESCRIPTION
## Summary
- Update swift-syntax dependency from 601.0.1 to 602.0.0 (Swift 6.2)
- Add `inlineArray` case to TypeModel for Swift 6.2 inline arrays (`[3 of Int]`)
- Remove obsolete `.token` case from `AttributeSyntax.Arguments` (API changed in 602)
- Remove retroactive `ExpressibleByStringLiteral` conformance warning
- Enable `--enable-experimental-prebuilts` in CI for faster builds

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (92 tests)
- [x] No warnings