### PR TITLE
Fix #if filtering when condition evaluates to false

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ swift run implicits-tool-spm-plugin <args-file>
    }
    ```
 
+## Development Process
+
+This project follows **strict TDD (Test-Driven Development)**:
+1. Write a test first
+2. Verify the test fails
+3. Implement the fix
+4. Verify the test passes
+
+Almost all code changes in this project happen this way.
+
 ## Important Constraints
 
 - Static analysis requires explicit type annotations (limited type inference)

--- a/Sources/TestResources/test_data/if_config_filtering.swift
+++ b/Sources/TestResources/test_data/if_config_filtering.swift
@@ -1,0 +1,60 @@
+@_spi(Unsafe)
+import Implicits
+
+// compilationConditions: ["A", "B", "C"]
+
+private func tests() {
+  withScope { scope in // expected-error {{Unresolved requirement: UInt8}}
+    #if A
+    @Implicit var _: UInt8
+    #else
+    @Implicit var _: UInt16
+    #endif
+  }
+
+  withScope { scope in // expected-error {{Unresolved requirement: UInt64}}
+    #if D
+    @Implicit var _: UInt32
+    #else
+    @Implicit var _: UInt64
+    #endif
+  }
+
+  withScope { scope in // expected-error {{Unresolved requirements: Int16, Int8}}
+    #if os(iOS)
+    @Implicit var _: Int8
+    #elseif A
+    @Implicit var _: Int16
+    #else
+    @Implicit var _: Int32
+    #endif
+  }
+
+  withScope { scope in // expected-error {{Unresolved requirement: Int}}
+    #if A
+      #if D
+      @Implicit var _: Float
+      #else
+      @Implicit var _: Int
+      #endif
+    #else
+    @Implicit var _: Double
+    #endif
+  }
+
+  withScope { scope in // expected-error {{Unresolved requirement: String}}
+    #if A && B
+    @Implicit var _: String
+    #else
+    @Implicit var _: Character
+    #endif
+  }
+
+  withScope { scope in // expected-error {{Unresolved requirement: Bool}}
+    #if !D
+    @Implicit var _: Bool
+    #else
+    @Implicit var _: Never
+    #endif
+  }
+}

--- a/Tests/ImplicitsToolTests/IfConfigTests.swift
+++ b/Tests/ImplicitsToolTests/IfConfigTests.swift
@@ -54,93 +54,10 @@ struct IfConfigTests {
     check("A ** B", nil)
     check("A = B", nil)
   }
-
-  @Test func ifConfig() throws {
-    func check(_ e: String, _ expected: String) {
-      let syntax = Syntax(Parser.parse(source: e))
-      let removed = removingInactiveIfConfig(
-        syntax, config: .enabled(["A", "B", "C"])
-      ).description
-      #expect(
-        removed.trim(\.isWhitespace) == expected.trim(\.isWhitespace),
-        "Expected \n\(e) to reduce into \n\(expected), but got \n\(removed)"
-      )
-    }
-
-    check(
-      """
-      #if A
-      let a = 1
-      #else
-      let b = 2
-      #endif
-      """,
-      """
-      #if A
-      let a = 1
-      #endif
-      """
-    )
-    check(
-      """
-      #if D
-      let a = 1
-      #else
-      let b = 2
-      #endif
-      """,
-      """
-      #if true
-      let b = 2
-      #endif
-      """
-    )
-    check(
-      """
-      #if os(iOS)
-      f(1)
-      #elseif A
-      f(2)
-      #else
-      f(3)
-      #endif
-      """,
-      """
-      #if os(iOS)
-      f(1)
-      #elseif A
-      f(2)
-      #endif
-      """
-    )
-  }
 }
 
 extension Bool? {
   fileprivate var descr: String {
     map { "\($0)" } ?? "nil"
-  }
-}
-
-extension StringProtocol {
-  func trim(
-    _ shouldTrim: (Character) -> Bool
-  ) -> Substring where SubSequence == Substring {
-    guard !isEmpty else { return self[startIndex..<startIndex] }
-    var start = startIndex
-    var end = index(before: endIndex)
-
-    while start <= end, shouldTrim(self[start]) {
-      start = index(after: start)
-    }
-
-    while end >= start, shouldTrim(self[end]) {
-      end = index(before: end)
-    }
-
-    if start > end {
-      return self[startIndex..<startIndex]
-    }
-    return self[start...end]
   }
 }

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -106,6 +106,10 @@ struct StaticAnalysisTests {
       ]
     )
   }
+
+  @Test func ifConfigFiltering() {
+    verify(file: "if_config_filtering.swift", compilationConditions: ["A", "B", "C"])
+  }
 }
 
 private let anotherModule = (modulename: "AnotherModule", files: ["another_module.swift"])

--- a/Tests/ImplicitsToolTests/TestSupport.swift
+++ b/Tests/ImplicitsToolTests/TestSupport.swift
@@ -14,12 +14,14 @@ func verify(
   file: String,
   enableExporting: Bool = false,
   supportFile: String? = nil,
+  compilationConditions: Set<String>? = nil,
   sourceLocation: Testing.SourceLocation = #_sourceLocation
 ) {
   verify(
     files: [file],
     enableExporting: enableExporting,
     supportFile: supportFile,
+    compilationConditions: compilationConditions,
     sourceLocation: sourceLocation
   )
 }
@@ -28,6 +30,7 @@ func verify(
   files: [String],
   enableExporting: Bool = false,
   supportFile: String? = nil,
+  compilationConditions: Set<String>? = nil,
   dependencies: [(modulename: String, files: [String])] = [],
   sourceLocation: Testing.SourceLocation = #_sourceLocation
 ) {
@@ -38,6 +41,7 @@ func verify(
       modulename: dep.modulename,
       enableExporting: false,
       supportFile: nil,
+      compilationConditions: compilationConditions,
       dependencies: [],
       sourceLocation: sourceLocation
     )
@@ -63,6 +67,7 @@ func verify(
     modulename: "TestModule",
     enableExporting: enableExporting,
     supportFile: supportFile,
+    compilationConditions: compilationConditions,
     dependencies: deserializedInterfaces,
     sourceLocation: sourceLocation
   )
@@ -73,16 +78,23 @@ func verify(
   modulename: String,
   enableExporting: Bool,
   supportFile: String?,
+  compilationConditions: Set<String>?,
   dependencies: [ImplicitModuleInterface],
   sourceLocation: Testing.SourceLocation
 ) -> ImplicitModuleInterface {
   let sources = files.map(TestSupport.readFile)
   let asts = sources.map(Parser.parse(source:))
+  let compilationConditionsConfig: CompilationConditionsConfig =
+    if let compilationConditions {
+      .enabled(compilationConditions)
+    } else {
+      .unknown
+    }
   let analysisRun = StaticAnalysis.run(
     files: zip(asts, files).map { .init(ast: $0, filename: $1) },
     modulename: modulename,
     dependencies: dependencies,
-    compilationConditions: .unknown,
+    compilationConditions: compilationConditionsConfig,
     enableExporting: enableExporting
   )
 


### PR DESCRIPTION
## Summary
- Fix bug in `filterInactiveIfConfig` where `#else` branches were incorrectly visited when `#if` condition evaluated to false
- Refactor to use switch with early return, eliminating `foundTrueBranch` flag
- Remove unused `removingInactiveIfConfig` and `ActiveIfConfigRewriter`
- Add integration test `ifConfigFiltering` with test data file

## Test plan
- [x] All 92 tests pass
- [x] New test covers: `#if A`, `#if D`, `#if os(iOS) #elseif A`, nested `#if`, `A && B`, `!D`