### PR TITLE
Add effect detection for closures (isAsync/isThrowing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,19 +53,19 @@ swift run implicits-tool-spm-plugin <args-file>
    }
    ```
 
-## Development Process
+## Testing
 
-This project follows **strict TDD (Test-Driven Development)**:
+This project follows **strict TDD** and has exhaustive test coverage:
 1. Write a test first
 2. Verify the test fails
-3. Implement the fix
+3. Implement the fix or feature
 4. Verify the test passes
 
-Almost all code changes in this project happen this way.
+- Integration tests are in `Sources/TestResources/test_data/` - check these for examples when implementing new features
+- Tests use inline annotations (e.g., `// expected-error`, `// expect-syntax:`) to specify expected behavior
 
 ## Important Constraints
 
 - Static analysis requires explicit type annotations (limited type inference)
 - No support for dynamic dispatch (protocols, closures) in static analysis
 - Scope objects must be explicitly passed as function parameters
-- Always check `TestResources/test_data` for examples when implementing new features

--- a/Sources/ImplicitsTool/GeneralVisitor.swift
+++ b/Sources/ImplicitsTool/GeneralVisitor.swift
@@ -39,6 +39,8 @@ struct GeneralVisitor<State>: @unchecked Sendable {
   var visitDoStmt: Visitor<DoStmtSyntax> = emptyVisitor()
   var visitClosureExpr: Visitor<ClosureExprSyntax> = emptyVisitor()
   var visitFunctionCallExpr: Visitor<FunctionCallExprSyntax> = emptyVisitor()
+  var visitTryExpr: Visitor<TryExprSyntax> = emptyVisitor()
+  var visitAwaitExpr: Visitor<AwaitExprSyntax> = emptyVisitor()
   var visitVariableDecl: Visitor<VariableDeclSyntax> = emptyVisitor()
   var visitMemberBlockItemList: Visitor<MemberBlockItemListSyntax> = emptyVisitor()
   var visitCodeBlockItemList: Visitor<CodeBlockItemListSyntax> = emptyVisitor()

--- a/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
@@ -623,6 +623,8 @@ extension SemaTreeBuilder.Context {
     case .other, .macroExpansion, .closure:
       diagnostics.diagnose(.unableToInferType, at: syntax)
       return nil
+    case let .await(expr), let .try(expr, _):
+      return resolveVariableType(expr, syntax: syntax)
     }
   }
 
@@ -793,7 +795,7 @@ extension SemaTreeBuilder.Context.VariableInfoForTypeInference {
         case .end, nil:
           return false
         }
-      case .declRef, .other, .memberAccessor, .macroExpansion, .closure:
+      case .declRef, .other, .memberAccessor, .macroExpansion, .closure, .await, .try:
         return false
       }
     }

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -155,6 +155,8 @@ public enum SyntaxTree<Syntax> {
     case declRef(String, parameters: [String]?)
     indirect case memberAccessor(base: Expression, String)
     case other([CodeBlockEntity])
+    indirect case `await`(Expression)
+    indirect case `try`(Expression, questionOrExclamation: Bool)
   }
 
   /// Represents initializer declaration
@@ -746,6 +748,10 @@ extension SyntaxTree.Expression {
       .memberAccessor(base: base.mapSyntax(t), v)
     case let .other(v):
       .other(v.map { $0.map(t, ST.CodeBlockStatement.mapSyntax) })
+    case let .await(expr):
+      .await(expr.mapSyntax(t))
+    case let .try(expr, questionOrExclamation):
+      .try(expr.mapSyntax(t), questionOrExclamation: questionOrExclamation)
     }
   }
 }

--- a/Sources/ImplicitsTool/SyntaxTreeEffectDetection.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeEffectDetection.swift
@@ -1,0 +1,104 @@
+// Copyright 2025 Yandex LLC. All rights reserved.
+
+extension SyntaxTree.ClosureExpr {
+  @_spi(Testing)
+  public var isAsync: Bool { body.contains(where: \.isAsync) }
+  @_spi(Testing)
+  public var isThrowing: Bool { body.contains(where: \.isThrowing) }
+}
+
+extension SyntaxTree.Expression {
+  var isAsync: Bool {
+    switch self {
+    case .await: true
+    case let .memberAccessor(base, _): base.isAsync
+    case let .other(entities): entities.contains(where: \.isAsync)
+    case let .try(expr, _): expr.isAsync
+    case let .functionCall(call): call.arguments.contains { $0.value.value.isAsync }
+    case .macroExpansion, .declRef, .closure: false
+    }
+  }
+
+  var isThrowing: Bool {
+    switch self {
+    case let .try(_, questionOrExclamation: q): !q
+    case let .memberAccessor(base, _): base.isThrowing
+    case let .other(entities): entities.contains(where: \.isThrowing)
+    case let .await(expr): expr.isThrowing
+    case let .functionCall(call): call.arguments.contains { $0.value.value.isThrowing }
+    case .macroExpansion, .declRef, .closure: false
+    }
+  }
+}
+
+extension SyntaxTree.CodeBlockStatement {
+  var isAsync: Bool {
+    switch self {
+    case let .decl(decl):
+      decl.isAsync
+    case let .stmt(stmt):
+      switch stmt {
+      case let .defer(stmts): stmts.contains(where: \.isAsync)
+      case let .do(doStmt): doStmt.body.contains(where: \.isAsync) || doStmt.catchBodies
+        .contains { $0.contains(where: \.isAsync) }
+      case let .other(items): items.contains(where: \.isAsync)
+      }
+    case let .expr(expr):
+      expr.isAsync
+    }
+  }
+
+  var isThrowing: Bool {
+    switch self {
+    case let .decl(decl):
+      decl.isThrowing
+    case let .stmt(stmt):
+      switch stmt {
+      case let .defer(stmts): stmts.contains(where: \.isThrowing)
+      case let .do(doStmt):
+        if doStmt.catchBodies.isEmpty {
+          doStmt.body.contains(where: \.isThrowing)
+        } else {
+          doStmt.catchBodies.contains { $0.contains(where: \.isThrowing) }
+        }
+      case let .other(items): items.contains(where: \.isThrowing)
+      }
+    case let .expr(expr):
+      expr.isThrowing
+    }
+  }
+}
+
+extension SyntaxTree.Declaration {
+  private func checkVarInitializers(_ predicate: (SyntaxTree.Expression) -> Bool) -> Bool {
+    switch self {
+    case let .variable(varDecl):
+      varDecl.bindings.contains {
+        guard let initializer = $0.initializer else { return false }
+        return predicate(initializer.value)
+      }
+    case .type, .protocol, .function, .memberBlock:
+      false
+    }
+  }
+
+  var isAsync: Bool { checkVarInitializers(\.isAsync) }
+  var isThrowing: Bool { checkVarInitializers(\.isThrowing) }
+}
+
+extension SyntaxTree.Argument.Value {
+  private func checkOther(_ predicate: (SyntaxTree.CodeBlockEntity) -> Bool) -> Bool {
+    switch self {
+    case let .other(entities): entities.contains(where: predicate)
+    case .keyed, .explicitType, .reference: false
+    }
+  }
+
+  var isAsync: Bool { checkOther(\.isAsync) }
+  var isThrowing: Bool { checkOther(\.isThrowing) }
+}
+
+extension SyntaxTree.Entity where T == SyntaxTree.CodeBlockStatement {
+  var isAsync: Bool { value.isAsync }
+  var isThrowing: Bool { value.isThrowing }
+}

--- a/Sources/TestResources/test_data/effect_detection.swift
+++ b/Sources/TestResources/test_data/effect_detection.swift
@@ -1,0 +1,72 @@
+private func effectDetectionTests() {
+  check { await asyncFunc() } // expect-syntax: async
+  check { plainFunc() }
+
+  check { try throwingFunc() } // expect-syntax: throws
+  check { try? throwingFunc() }
+  check { try! throwingFunc() }
+
+  check { try! throwingFunc(try throwingFunc()) }
+  check { try? throwingFunc(try throwingFunc()) }
+
+  check { try await asyncThrowingFunc() } // expect-syntax: async, throws
+  check { try? await asyncThrowingFunc() } // expect-syntax: async
+  check { try! await asyncThrowingFunc() } // expect-syntax: async
+
+  check { let _ = await asyncFunc() } // expect-syntax: async
+  check { let _ = try throwingFunc() } // expect-syntax: throws
+
+  check {
+    do {
+      try throwingFunc()
+    } catch {}
+  }
+
+  check { // expect-syntax: throws
+    do {
+      try throwingFunc()
+    } catch {
+      try throwingFunc()
+    }
+  }
+
+  check { // expect-syntax: throws
+    do {
+      try throwingFunc()
+    }
+  }
+
+  check { if true { await asyncFunc() } } // expect-syntax: async
+  check { if true { try throwingFunc() } } // expect-syntax: throws
+
+  check { for _ in [] as [Int] { await asyncFunc() } } // expect-syntax: async
+  check { for _ in [] as [Int] { try throwingFunc() } } // expect-syntax: throws
+
+  check { takes(await asyncFunc()) } // expect-syntax: async
+  check { takes(try throwingFunc()) } // expect-syntax: throws
+
+  check {
+    Task {
+      await asyncFunc()
+    }
+  }
+
+  check {
+    check { // expect-syntax: throws
+      try throwingFunc()
+    }
+  }
+
+  check {
+    check { // expect-syntax: async
+      await asyncFunc()
+    }
+  }
+}
+
+private func check(_ closure: () async throws -> Void) {}
+private func asyncFunc() async {}
+private func throwingFunc(_: Void? = nil) throws {}
+private func asyncThrowingFunc() async throws {}
+private func plainFunc() {}
+private func takes(_: Void) {}

--- a/Tests/ImplicitsToolTests/EffectDetectionTests.swift
+++ b/Tests/ImplicitsToolTests/EffectDetectionTests.swift
@@ -1,0 +1,96 @@
+// Copyright 2025 Yandex LLC. All rights reserved.
+
+import Testing
+
+@_spi(Testing) import ImplicitsTool
+import SwiftParser
+import SwiftSyntax
+import TestResources
+
+struct EffectDetectionTests {
+  @Test func closureEffects() {
+    verifySyntax(file: "effect_detection.swift", using: ClosureEffectVerifier.self)
+  }
+}
+
+// MARK: - Closure Effect Verifier
+
+enum ClosureEffect: String, CaseIterable {
+  case async
+  case `throws`
+}
+
+struct ClosureEffectVerifier: SyntaxVerifier, Sendable {
+  func extractNodes(
+    from syntaxTree: [SyntaxTree<Syntax>.TopLevelEntity],
+    locationConverter: SourceLocationConverter
+  ) -> [SyntaxNodeResult<ClosureEffect>] {
+    var results: [SyntaxNodeResult<ClosureEffect>] = []
+
+    for entity in syntaxTree {
+      if case let .declaration(.function(funcDecl)) = entity.value {
+        for item in funcDecl.body ?? [] {
+          results.append(contentsOf: extractFromStatement(
+            item,
+            locationConverter: locationConverter
+          ))
+        }
+      }
+    }
+
+    return results
+  }
+
+  private func extractFromStatement(
+    _ statement: SyntaxTree<Syntax>.CodeBlockEntity,
+    locationConverter: SourceLocationConverter
+  ) -> [SyntaxNodeResult<ClosureEffect>] {
+    if case let .expr(expr) = statement.value {
+      return extractFromExpression(expr, locationConverter: locationConverter)
+    }
+    return []
+  }
+
+  private func extractFromExpression(
+    _ expression: SyntaxTree<Syntax>.Expression,
+    locationConverter: SourceLocationConverter
+  ) -> [SyntaxNodeResult<ClosureEffect>] {
+    switch expression {
+    case let .functionCall(call):
+      guard case .identifier("check") = call.name?.value else { return [] }
+      var results: [SyntaxNodeResult<ClosureEffect>] = []
+      if let trailingClosure = call.trailingClosure {
+        results.append(contentsOf: extractFromClosure(
+          trailingClosure,
+          locationConverter: locationConverter
+        ))
+      }
+      return results
+    default:
+      return []
+    }
+  }
+
+  private func extractFromClosure(
+    _ closure: SyntaxTree<Syntax>.Entity<SyntaxTree<Syntax>.ClosureExpr>,
+    locationConverter: SourceLocationConverter
+  ) -> [SyntaxNodeResult<ClosureEffect>] {
+    let line = closure.syntax.startLocation(converter: locationConverter).line
+
+    var properties: Set<ClosureEffect> = []
+    if closure.value.isAsync {
+      properties.insert(.async)
+    }
+    if closure.value.isThrowing {
+      properties.insert(.throws)
+    }
+
+    var results = [SyntaxNodeResult(line: line, properties: properties)]
+
+    for item in closure.value.body {
+      results.append(contentsOf: extractFromStatement(item, locationConverter: locationConverter))
+    }
+
+    return results
+  }
+}


### PR DESCRIPTION
Part of #5 (async/throws detection for closures)

## Summary
- Add `.await` and `.try` cases to Expression enum
- Parse `TryExprSyntax` and `AwaitExprSyntax` into syntax tree
- Handle try/await in SemaTreeBuilder and type resolution
- Implement `isAsync`/`isThrowing` on `ClosureExpr`
- `try?`/`try!` correctly suppress throwing, bare `try` propagates

## Test plan
- [x] All 95 tests pass
- [x] Effect detection tests cover: try, try?, try!, await, try await, try? await, do-catch, nested closures