### PR TITLE
Add warning for anonymous implicit variables

### DIFF
--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -639,9 +639,13 @@ enum SemaTreeBuilder<
       context: &context
     )
     if let implicit {
-      nestedNodes.append(
-        .init(syntax: syntax, node: .implicit(implicit))
-      )
+      if binding.name.isWildcard {
+        context.diagnose(.anonymousImplicit, at: syntax)
+      } else {
+        nestedNodes.append(
+          .init(syntax: syntax, node: .implicit(implicit))
+        )
+      }
     }
 
     return nestedNodes
@@ -1557,6 +1561,9 @@ extension DiagnosticMessage {
 
   fileprivate static let storedPropertyInSetMode: Self =
     "Stored Implicit property cannot have initial value"
+  
+  fileprivate static let anonymousImplicit: Self =
+    "Anonymous implicit will not be saved to context"
 
   // MARK: Scopes
 

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -961,3 +961,12 @@ extension SyntaxTree.Argument {
     )
   }
 }
+
+extension SyntaxTree.VariableDecl.Pattern {
+  var isWildcard: Bool {
+    switch self {
+    case .wildcard: true
+    case .identifier, .tuple, .unsupported: false
+    }
+  }
+}

--- a/Sources/TestResources/test_data/graph_basic.swift
+++ b/Sources/TestResources/test_data/graph_basic.swift
@@ -9,20 +9,20 @@ func topLevel1() {
   defer { scope.end() }
 
   @Implicit()
-  var _: Dep1 = Dep1()
+  var d1: Dep1 = Dep1()
 
   @Implicit
-  var _: Dep2 = Dep2()
+  var d2: Dep2 = Dep2()
 
   @Implicit
-  var _: Dep3 = Dep3()
+  var d3: Dep3 = Dep3()
 
   if Bool.random() {
     let scope = scope.nested()
     defer { scope.end() }
 
     @Implicit
-    var _: Dep3 = Dep3()
+    var d4: Dep3 = Dep3()
 
     lowest(scope)
   }
@@ -35,10 +35,10 @@ func topLevel2() {
   defer { scope.end() }
 
   @Implicit()
-  var _: Dep1 = Dep1()
+  var d1: Dep1 = Dep1()
 
   @Implicit
-  var _: Dep2 = Dep2()
+  var d2: Dep2 = Dep2()
 }
 
 func topLevel3() {
@@ -46,10 +46,10 @@ func topLevel3() {
   defer { scope.end() }
 
   @Implicit()
-  var _: Dep1 = Dep1()
+  var d1: Dep1 = Dep1()
 
   @Implicit
-  var _: Dep2 = Dep2()
+  var d2: Dep2 = Dep2()
 
   intermediate1(scope)
 }
@@ -63,7 +63,7 @@ func intermediate2(_ scope: ImplicitScope) {
   defer { scope.end() }
 
   @Implicit
-  var _: Dep3 = Dep3()
+  var d1: Dep3 = Dep3()
 
   lowest(scope)
 }

--- a/Sources/TestResources/test_data/if_config_filtering.swift
+++ b/Sources/TestResources/test_data/if_config_filtering.swift
@@ -6,55 +6,55 @@ import Implicits
 private func tests() {
   withScope { scope in // expected-error {{Unresolved requirement: UInt8}}
     #if A
-    @Implicit var _: UInt8
+    @Implicit() var v1: UInt8
     #else
-    @Implicit var _: UInt16
+    @Implicit() var v2: UInt16
     #endif
   }
 
   withScope { scope in // expected-error {{Unresolved requirement: UInt64}}
     #if D
-    @Implicit var _: UInt32
+    @Implicit() var v1: UInt32
     #else
-    @Implicit var _: UInt64
+    @Implicit() var v1: UInt64
     #endif
   }
 
   withScope { scope in // expected-error {{Unresolved requirements: Int16, Int8}}
     #if os(iOS)
-    @Implicit var _: Int8
+    @Implicit() var v1: Int8
     #elseif A
-    @Implicit var _: Int16
+    @Implicit() var v1: Int16
     #else
-    @Implicit var _: Int32
+    @Implicit() var v1: Int32
     #endif
   }
 
   withScope { scope in // expected-error {{Unresolved requirement: Int}}
     #if A
       #if D
-      @Implicit var _: Float
+      @Implicit() var v1: Float
       #else
-      @Implicit var _: Int
+      @Implicit() var v1: Int
       #endif
     #else
-    @Implicit var _: Double
+    @Implicit() var v1: Double
     #endif
   }
 
   withScope { scope in // expected-error {{Unresolved requirement: String}}
     #if A && B
-    @Implicit var _: String
+    @Implicit() var v1: String
     #else
-    @Implicit var _: Character
+    @Implicit() var v1: Character
     #endif
   }
 
   withScope { scope in // expected-error {{Unresolved requirement: Bool}}
     #if !D
-    @Implicit var _: Bool
+    @Implicit() var v1: Bool
     #else
-    @Implicit var _: Never
+    @Implicit() var v1: Never
     #endif
   }
 }

--- a/Sources/TestResources/test_data/implicit_scope_order.swift
+++ b/Sources/TestResources/test_data/implicit_scope_order.swift
@@ -55,13 +55,13 @@ private func entry1() {
   func nestedFunc2() {
     // expected-error@+2 {{Using implicits without 'ImplicitScope'}}
     @Implicit()
-    var _: UInt32
+    var v1: UInt32
   }
 
   // expected-error@+1 {{Nested functions with scope parameter are not supported}}
   func nestedFuncWithScope(_ scope: ImplicitScope) {
     @Implicit()
-    var _: UInt32
+    var v1: UInt32
   }
 
   func nestedFuncWithNestedScope() {
@@ -77,7 +77,7 @@ private func entry1() {
     defer { scope.end() }
 
     @Implicit()
-    var _: UInt64
+    var v1: UInt64
   }
 
   if Bool.random() {

--- a/Sources/TestResources/test_data/syntax_structure.swift
+++ b/Sources/TestResources/test_data/syntax_structure.swift
@@ -111,6 +111,17 @@ private func entry3() {
 }
 #endif
 
+func `underscore variable name`() {
+  let scope = ImplicitScope() // expected-error {{Unresolved requirement: Int}}
+  defer { scope.end() }
+  
+  @Implicit()
+  var _: Int = 42 // expected-error {{Anonymous implicit will not be saved to context}}
+  
+  @Implicit()
+  var v1: Int
+}
+
 // expected-error@+2 {{'ImplicitScope' argument in function declaration must be wildcard. Possible variants are: '_: ImplicitScope' or '_ scope: ImplicitScope'}}
 // expected-error@+1 {{Excess 'ImplicitScope' parameter in function declaration}}
 private func f1(scope: ImplicitScope, _: ImplicitScope) {

--- a/Sources/TestResources/test_data/with_named_implicits.swift
+++ b/Sources/TestResources/test_data/with_named_implicits.swift
@@ -7,15 +7,15 @@ private func basicUsage() {
   defer { scope.end() }
 
   let _: () -> Void = withZeroArgsImplicits { scope in
-    @Implicit var _: UInt8
+    @Implicit() var v1: UInt8
   }
 
   let _: (Int) -> Void = withOneArgImplicits { (a: Int, scope) in
-    @Implicit var _: UInt16
+    @Implicit() var v1: UInt16
   }
 
   let _: (String, Bool) -> Void = withTwoArgsImplicits { (a: String, b: Bool, scope) in
-    @Implicit var _: UInt32
+    @Implicit() var v1: UInt32
   }
 }
 
@@ -25,10 +25,10 @@ private func nestedWrappers() {
   defer { scope.end() }
 
   _ = withOuterImplicits { scope in
-    @Implicit var _: Int8
+    @Implicit() var v1: Int8
 
     _ = withInnerImplicits { (_: Int, scope) in
-      @Implicit var _: Int16
+      @Implicit() var v2: Int16
     }
   }
 }
@@ -40,11 +40,11 @@ private func conditionalBranches() {
 
   if Bool.random() {
     _ = withBranchAImplicits { scope in
-      @Implicit var _: Int32
+      @Implicit() var v1: Int32
     }
   } else {
     _ = withBranchBImplicits { (_: Int, scope) in
-      @Implicit var _: Int64
+      @Implicit() var v1: Int64
     }
   }
 }
@@ -59,7 +59,7 @@ private func bagCapture() {
     defer { scope.end() }
 
     _ = withBagImplicits { scope in
-      @Implicit var _: Float
+      @Implicit() var v1: Float
     }
   }
   closure()
@@ -68,22 +68,22 @@ private func bagCapture() {
 private func missingScope() {
   // expected-error@+1 {{Using implicits without 'ImplicitScope'}}
   let _: () -> Void = withOrphanImplicits { scope in
-    @Implicit var _: Double
+    @Implicit() var v1: Double
   }
 }
 
 private func duplicateNames(_: ImplicitScope) {
   // expected-note@+1 {{Previous wrapper here}}
   _ = withDuplicateImplicits { scope in
-    @Implicit var _: UInt8
+    @Implicit() var v1: UInt8
   }
 
   // expected-error@+1 {{Implicit closure wrappers must have unique names, 'withDuplicateImplicits' is already defined}}
   _ = withDuplicateImplicits { scope in
-    @Implicit var _: Int8
+    @Implicit() var v1: Int8
   }
 
   _ = withDuplicateImplicits { scope in
-    @Implicit var _: Int16
+    @Implicit() var v1: Int16
   }
 }

--- a/Sources/TestResources/test_data/with_scope.swift
+++ b/Sources/TestResources/test_data/with_scope.swift
@@ -18,7 +18,7 @@ private func entry() throws {
       defer { scope.end() }
 
       @Implicit()
-      var _: UInt16 = 0
+      var v1: UInt16 = 0
 
       requireUInt8(scope)
       requireUInt16(scope)
@@ -156,7 +156,7 @@ private func requireUInt8(_ scope: ImplicitScope) {
 
 private func requireUInt16(_ scope: ImplicitScope) {
   @Implicit()
-  var _: UInt16
+  var v1: UInt16
 }
 
 private struct Err: Error {}


### PR DESCRIPTION
## Summary
- Added diagnostic warning when using anonymous implicits (`var _: Type`)
- Anonymous implicits won't be saved to context, so this warns users about likely mistakes
- Updated all test files to use named variables instead of wildcards

## Test plan
- [x] Existing tests pass with updated variable names
- [x] New test case in `syntax_structure.swift` verifies the warning is emitted