### PR TITLE
Add support for #if blocks inside code blocks

### DIFF
--- a/Sources/ImplicitsTool/SemaTree.swift
+++ b/Sources/ImplicitsTool/SemaTree.swift
@@ -77,6 +77,7 @@ enum SemaTree<Syntax> {
     case withNamedImplicits(wrapperName: String, closureParamCount: Int, body: [CodeBlockItem])
     case implicitMap(from: ImplicitKey, to: ImplicitKey)
     case implicit(Implicit)
+    case unresolvedIfConfigBlock(condition: Syntax, body: [CodeBlockItem])
   }
 
   typealias TopLevel = WithSyntax<TopLevelNode>
@@ -257,6 +258,11 @@ extension SemaTree.CodeBlockItemNode {
       )
     case let .implicitMap(from: from, to: to):
       .implicitMap(from: from, to: to)
+    case let .unresolvedIfConfigBlock(condition: condition, body: body):
+      .unresolvedIfConfigBlock(
+        condition: transform(condition),
+        body: body.map { $0.mapSyntax(transform) }
+      )
     }
   }
 }

--- a/Sources/ImplicitsTool/SyntaxTreeEffectDetection.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeEffectDetection.swift
@@ -45,6 +45,8 @@ extension SyntaxTree.CodeBlockStatement {
       }
     case let .expr(expr):
       expr.isAsync
+    case let .ifConfig(ifConfig):
+      ifConfig.clauses.contains { $0.body.contains(where: \.isAsync) }
     }
   }
 
@@ -65,6 +67,8 @@ extension SyntaxTree.CodeBlockStatement {
       }
     case let .expr(expr):
       expr.isThrowing
+    case let .ifConfig(ifConfig):
+      ifConfig.clauses.contains { $0.body.contains(where: \.isThrowing) }
     }
   }
 }

--- a/Sources/TestResources/test_data/if_config_code_block.swift
+++ b/Sources/TestResources/test_data/if_config_code_block.swift
@@ -1,0 +1,104 @@
+import Implicits
+
+private func ifConfigCodeBlock() {
+  withScope { scope in
+    @Implicit var v0: Bool = false
+
+    #if canImport(M1)
+    // expected-note@-1 {{Unable to resolve condition}}
+    // expected-error@+1 {{Cannot mutate implicit context inside '#if' block with unresolved condition}}
+    @Implicit var v1: UInt8 = 0
+    #endif
+  }
+  
+  if Bool.random() {
+    #if canImport(M2)
+    // expected-note@-1 {{Unable to resolve condition}}
+    // expected-error@+1 {{Cannot create implicit scope inside '#if' block with unresolved condition}}
+    let scope = ImplicitScope()
+    defer { scope.end() }
+    // expected-error@+1 {{Cannot mutate implicit context inside '#if' block with unresolved condition}}
+    @Implicit var v1: UInt16 = 0
+    #endif
+  }
+
+  withScope { scope in
+    #if canImport(M1)
+    // expected-note@-1 {{Unable to resolve condition}}
+    otherCode()
+    #else
+    // expected-error@+1 {{Cannot mutate implicit context inside '#if' block with unresolved condition}}
+    @Implicit var v1: UInt32 = 0
+    #endif
+  }
+
+  withScope { scope in
+    #if canImport(M1)
+    otherCode()
+    #elseif canImport(M2)
+    // expected-note@-1 {{Unable to resolve condition}}
+    otherCode()
+    #else
+    // expected-error@+1 {{Cannot mutate implicit context inside '#if' block with unresolved condition}}
+    @Implicit var v1: UInt64 = 0
+    #endif
+  }
+
+  // expected-error@+1 {{Unresolved requirement: UInt32}}
+  withScope { scope in
+    @Implicit var v1: UInt8 = 0
+    #if canImport(M1)
+    // expected-warning@+2 {{Implicitly overriding existing scope}}
+    // expected-error@+1 {{Unresolved requirement: UInt16}}
+    withScope { scope in
+      @Implicit var v2: UInt8 = 0
+      requiresUInt8(scope)
+      requiresUInt16(scope)
+    }
+    #elseif canImport(M2)
+    withScope(nesting: scope) { scope in 
+      @Implicit var v2: UInt16 = 0
+      requiresUInt8(scope)
+      requiresUInt16(scope)
+      requiresUInt32(scope)
+    }
+    #endif
+  }
+
+  // expected-error@+1 {{Unresolved requirements: UInt16, UInt32, UInt8}}
+  withScope{ scope in
+    #if canImport(M1)
+    requiresUInt8(scope)
+    #elseif canImport(M2)
+    requiresUInt16(scope)
+    #else
+    requiresUInt32(scope)
+    #endif
+  }
+
+  // expected-error@+1 {{Unresolved requirement: UInt16}}
+  withScope { scope in
+    #if canImport(M1)
+    if Bool.random() {
+      let scope = scope.nested()
+      defer { scope.end() }
+      @Implicit var v2: UInt8 = 0
+      requiresUInt8(scope)
+      requiresUInt16(scope)
+    }
+    #endif
+  }
+}
+
+private func otherCode() {}
+
+private func requiresUInt8(_: ImplicitScope) {
+  @Implicit() var v: UInt8
+}
+
+private func requiresUInt16(_: ImplicitScope) {
+  @Implicit() var v: UInt16
+}
+private func requiresUInt32(_: ImplicitScope) {
+  @Implicit() var v: UInt32
+}

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -110,6 +110,10 @@ struct StaticAnalysisTests {
   @Test func ifConfigFiltering() {
     verify(file: "if_config_filtering.swift", compilationConditions: ["A", "B", "C"])
   }
+
+  @Test func ifConfigCodeBlock() {
+    verify(file: "if_config_code_block.swift")
+  }
 }
 
 private let anotherModule = (modulename: "AnotherModule", files: ["another_module.swift"])


### PR DESCRIPTION
## Summary
- Handle unresolved `#if` conditions within function bodies with proper restrictions
- Track `insideIfConfigCondition` separately from scope state  
- Block `@Implicit` assignments, `ImplicitScope()`, and `scope.nested()` directly in `#if` blocks
- Allow `scope.nested()` after entering language-level inner scope (if/while/for resets #if context)
- Propagate unresolved requirements from all `#if` branches

## Test plan
- [x] Added `if_config_code_block.swift` test file with various scenarios
- [x] All 98 existing tests pass