### PR TITLE
Isolate child task implicit scopes from parent tasks

### DIFF
--- a/Sources/Implicits/TaskLocalUtils.swift
+++ b/Sources/Implicits/TaskLocalUtils.swift
@@ -20,6 +20,23 @@ func isAsyncContext() -> Bool {
   withUnsafeCurrentTask { $0 != nil }
 }
 
+class UnmanagedAsyncTaskWrapper {}
+
+// Mirrors Builtin.retain(_task) in stdlib's withUnsafeCurrentTask
+// to prevent "destroying a task that never completed" crashes.
+// See: github.com/swiftlang/swift/blob/swift-6.0-RELEASE/stdlib/public/Concurrency/Task.swift#L686
+@available(iOS 13, macOS 10.15, *)
+func currentTaskID() -> ObjectIdentifier? {
+  guard isAsyncContext(), let task = _getCurrentAsyncTask()
+  else { return nil }
+  let classTask = unsafeBitCast(task, to: UnmanagedAsyncTaskWrapper.self)
+  let unmanagedTask = Unmanaged.passRetained(classTask)
+  let id = unsafeBitCast(
+    unmanagedTask.takeUnretainedValue(), to: ObjectIdentifier.self
+  )
+  return id
+}
+
 private protocol BuiltinRawPointerTypeExtractor {
   associatedtype BuiltinRawPointer
   var _rawValue: BuiltinRawPointer { get }


### PR DESCRIPTION
## Summary
- Child tasks in Swift Concurrency were incorrectly sharing the parent task's RawStore via TaskLocal inheritance
- Each task now tracks its owning task ID and creates an isolated store when detecting inheritance from a different task
- Prevents implicit values from leaking between sibling tasks

## Test plan
- [x] Added `childTasksScopesShouldBeIsolated` test that verifies two concurrent child tasks maintain separate implicit scopes
- [x] All existing concurrency tests pass