### PR TITLE
Detect Objective-C generic types used as implicit keys

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,7 @@ let package = Package(
       name: "__TestResourcesCompilation",
       dependencies: ["Implicits", "AnotherModule"],
       path: "Sources/TestResources/test_data",
-      exclude: ["another_module.swift"]
+      exclude: ["another_module.swift", "objc_generic_types.swift"]
     ),
     .target(
       name: "AnotherModule",

--- a/README.md
+++ b/README.md
@@ -388,6 +388,29 @@ var networkService = NetworkService()
 var networkService = services.network
 ```
 
+**4. Objective-C Lightweight Generics**
+- Objective-C generic types (`NSArray<T>`, `NSDictionary<K,V>`, etc.) cannot be used as type-based implicit keys
+- Generic parameters are erased at runtime: `ObjectIdentifier(NSArray<NSString>.self) == ObjectIdentifier(NSArray<NSNumber>.self)`
+- Use named keys (keypaths) instead:
+
+```swift
+// Won't work - type-erased at runtime
+@Implicit
+var strings: NSArray<NSString>
+
+// Use named keys instead
+extension ImplicitsKeys {
+  var stringArray: NSArray<NSString> { get { fatalError() } }
+  var numberArray: NSArray<NSNumber> { get { fatalError() } }
+}
+
+@Implicit(\.stringArray)
+var strings: NSArray<NSString>
+
+@Implicit(\.numberArray)
+var numbers: NSArray<NSNumber>
+```
+
 ## Runtime Debugging
 
 In DEBUG builds, Implicits provides powerful debugging tools to inspect your implicit context at runtime.

--- a/Sources/ImplicitsTool/SemaCommonDiagnostics.swift
+++ b/Sources/ImplicitsTool/SemaCommonDiagnostics.swift
@@ -12,4 +12,9 @@ extension DiagnosticMessage {
   }
 
   static let foundCandidate: Self = "Found this candidate"
+
+  // Objective-C generic types
+  static func objcGenericTypeKey(_ typeName: String) -> Self {
+    "'\(typeName)' is an Objective-C type with type-erased generics; use a named key (keypath) instead of type-as-key"
+  }
 }

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1489,6 +1489,10 @@ extension ImplicitKey {
     errors: inout Diagnostics<S>,
     syntax: S
   ) {
+    if let objcType = type.objcGenericBaseType {
+      errors.diagnose(.objcGenericTypeKey(objcType), at: syntax)
+    }
+
     self.init(
       kind: .type,
       name: type.strictDescription(errors: &errors, syntax: syntax)

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -914,6 +914,30 @@ extension SyntaxTree.TypeModel {
   }
 }
 
+private let knownObjcGenericTypes: Set<String> = [
+  "NSArray", "NSMutableArray",
+  "NSDictionary", "NSMutableDictionary",
+  "NSSet", "NSMutableSet",
+  "NSOrderedSet", "NSMutableOrderedSet",
+  "NSEnumerator",
+  "NSCache",
+  "NSMapTable", "NSHashTable", "NSPointerArray",
+]
+
+extension SyntaxTree.TypeModel {
+  /// ObjC lightweight generics are type-erased at runtime.
+  var objcGenericBaseType: String? {
+    guard case let .generic(base, args) = self,
+          !args.isEmpty,
+          case let .identifier(name) = base,
+          knownObjcGenericTypes.contains(name) || name.hasPrefix("NS")
+    else {
+      return nil
+    }
+    return name
+  }
+}
+
 extension SyntaxTree.Attribute {
   func mapSyntax<S>(_ t: (Syntax) -> S) -> SyntaxTree<S>.Attribute {
     .init(

--- a/Sources/TestResources/test_data/objc_generic_types.swift
+++ b/Sources/TestResources/test_data/objc_generic_types.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Implicits
+
+func testObjcGenericTypes() {
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  // Objective-C generic types should produce errors
+  @Implicit
+  var arr1: NSArray<NSString> = NSArray() // expected-error {{'NSArray' is an Objective-C type with type-erased generics; use a named key (keypath) instead of type-as-key}}
+
+  @Implicit
+  var dict1: NSDictionary<NSString, NSNumber> = NSDictionary() // expected-error {{'NSDictionary' is an Objective-C type with type-erased generics; use a named key (keypath) instead of type-as-key}}
+
+  @Implicit
+  var set1: NSSet<NSString> = NSSet() // expected-error {{'NSSet' is an Objective-C type with type-erased generics; use a named key (keypath) instead of type-as-key}}
+
+  @Implicit
+  var orderedSet1: NSOrderedSet<NSString> = NSOrderedSet() // expected-error {{'NSOrderedSet' is an Objective-C type with type-erased generics; use a named key (keypath) instead of type-as-key}}
+
+  // Non-generic ObjC types should be fine
+  @Implicit
+  var str: NSString = ""
+
+  @Implicit
+  var number: NSNumber = 0
+
+  // Swift generic types should be fine
+  @Implicit
+  var swiftArr: Array<String> = []
+
+  @Implicit
+  var swiftDict: Dictionary<String, Int> = [:]
+}

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -114,6 +114,10 @@ struct StaticAnalysisTests {
   @Test func ifConfigCodeBlock() {
     verify(file: "if_config_code_block.swift", compilationConditions: ["A", "B", "C"])
   }
+
+  @Test func objcGenericTypes() {
+    verify(file: "objc_generic_types.swift")
+  }
 }
 
 private let anotherModule = (modulename: "AnotherModule", files: ["another_module.swift"])


### PR DESCRIPTION
Fixes #12

Adds static analysis error when Objective-C generic types are used as implicit type keys, since their generics are type-erased at runtime causing key collisions.