### PR TITLE
Add async/throws effects support for named implicits wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ This project follows **strict TDD**:
 - Integration tests are in `Sources/TestResources/test_data/` - check these for examples when implementing new features
 - Tests use inline annotations (e.g., `// expected-error`, `// expect-syntax:`) to specify expected behavior
 
+## File Organization
+
+- **Main type first**: The primary type of a file goes at the top. If a file is named `Foo.swift`, the `Foo` type should be at the top.
+- **Helper/utility types at the bottom**: Supporting structs, enums, extensions, and helper types go after the main type, not before it.
+- **Extensions of the main type**: Place extensions of the file's main type immediately after the main type definition.
+- **Extensions of other types**: Place extensions of unrelated types (like `DiagnosticMessage`) at the bottom.
+
 ## Important Constraints
 
 - Static analysis requires explicit type annotations (limited type inference)

--- a/Sources/ImplicitsTool/ClosureEffects.swift
+++ b/Sources/ImplicitsTool/ClosureEffects.swift
@@ -1,0 +1,32 @@
+// Copyright 2025 Yandex LLC. All rights reserved.
+
+import SwiftSyntax
+
+/// Represents the effects (async/throwing) of a closure used in named implicits wrappers.
+public struct ClosureEffects: Equatable, Sendable {
+  public var isAsync: Bool
+  public var isThrowing: Bool
+
+  static let none = Self(isAsync: false, isThrowing: false)
+
+  /// Returns effect specifiers syntax for use in function types.
+  var effectSpecifiers: TypeEffectSpecifiersSyntax? {
+    guard isAsync || isThrowing else { return nil }
+    return TypeEffectSpecifiersSyntax(
+      asyncSpecifier: isAsync ? .keyword(.async) : nil,
+      throwsClause: isThrowing ? ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws)) : nil
+    )
+  }
+
+  /// Wraps a function call expression with `try` and/or `await` as needed based on effects.
+  func wrapCall(_ call: FunctionCallExprSyntax) -> ExprSyntax {
+    var expr = ExprSyntax(call)
+    if isAsync {
+      expr = ExprSyntax(AwaitExprSyntax(expression: expr))
+    }
+    if isThrowing {
+      expr = ExprSyntax(TryExprSyntax(expression: expr))
+    }
+    return expr
+  }
+}

--- a/Sources/ImplicitsTool/RequirementsGraph.swift
+++ b/Sources/ImplicitsTool/RequirementsGraph.swift
@@ -12,11 +12,13 @@ public struct RequirementsGraph<Syntax, File> {
     }
   }
 
+  typealias WrapperInfo<Resolution> = ImplicitsTool.WrapperInfo<Resolution, File>
+
   typealias Graph = OrderedGraph<Node, Void>
   var graph: Graph
   var entryPoints: [Graph.Index]
   var bags: [(Graph.Index, name: String, File)]
-  var namedImplicitsWrappers: [(Graph.Index, wrapperName: String, closureParamCount: Int, File)]
+  var namedImplicitsWrappers: [WrapperInfo<Graph.Index>]
   var publicInterface: [(Graph.Index, Symbol)]
   var testableInterface: [(Graph.Index, Symbol)]
   var implicitFunctions: [(Graph.Index, File, SemaTree<Syntax>.FuncDecl)]
@@ -26,12 +28,7 @@ extension RequirementsGraph {
   typealias Diagnostics = DiagnosticsGeneric<Syntax>
   struct ResolveRequirementsResult {
     var bags: [(name: String, requirements: [ImplicitKey], File)]
-    var namedImplicitsWrappers: [(
-      wrapperName: String,
-      closureParamCount: Int,
-      requirements: [ImplicitKey],
-      File
-    )]
+    var namedImplicitsWrappers: [WrapperInfo<[ImplicitKey]>]
     var publicInterface: [(Symbol, [ImplicitKey])]
     var testableInterface: [(Symbol, [ImplicitKey])]
     var implicitFunctions: [(SemaTree<Syntax>.FuncDecl, File, [ImplicitKey])]
@@ -55,14 +52,15 @@ extension RequirementsGraph {
       file: $0.2
     ) }
     let namedImplicitsWrappers = self.namedImplicitsWrappers
-      .map { idx, wrapperName, paramCount, file in
-        let reqs = resolveRequirements(from: idx, cache: &cache, path: [])
+      .map { wrapper in
+        let reqs = resolveRequirements(from: wrapper.resolution, cache: &cache, path: [])
           .sorted { $0.lexicographicalOrder < $1.lexicographicalOrder }
-        return (
-          wrapperName: wrapperName,
-          closureParamCount: paramCount,
-          requirements: reqs,
-          file: file
+        return WrapperInfo(
+          wrapperName: wrapper.wrapperName,
+          closureParamCount: wrapper.closureParamCount,
+          effects: wrapper.effects,
+          resolution: reqs,
+          file: wrapper.file
         )
       }
     let publicInterface = self.publicInterface.map { index, signature in
@@ -129,4 +127,12 @@ extension DiagnosticMessage {
       .sorted().joined(separator: ", ")
     return "Unresolved requirement\(reqs.count > 1 ? "s" : ""): \(reqString)"
   }
+}
+
+struct WrapperInfo<Resolution, File> {
+  var wrapperName: String
+  var closureParamCount: Int
+  var effects: ClosureEffects
+  var resolution: Resolution
+  var file: File
 }

--- a/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
+++ b/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
@@ -39,7 +39,7 @@ private struct UnresolvedGraph<Syntax, File> {
   var implicitStoredProperties = [Sema.Namespace: (head: Idx, tail: Idx)]()
   var initializers = [Sema.Namespace: [Idx]]()
   var bags = [(SMT.ImplicitBag, Idx, File)]()
-  var namedImplicitsWrappers = [(wrapperName: String, closureParamCount: Int, Idx, File)]()
+  var namedImplicitsWrappers = [ReqGraph.WrapperInfo<Idx>]()
   var seenWrapperNames = [String: Syntax?]() // nil = already reported duplicate
   var diagnostics = Diagnostics()
   var publicInterface = [(Idx, SymbolInfo<Syntax>)]()
@@ -54,12 +54,7 @@ private struct UnresolvedGraph<Syntax, File> {
     RequirementsGraph<Syntax, File>(
       graph: graph, entryPoints: entryPoints,
       bags: bags.map { ($0.1, name: $0.0.node.fillFunctionName, $0.2) },
-      namedImplicitsWrappers: namedImplicitsWrappers.map { (
-        $0.2,
-        $0.wrapperName,
-        $0.closureParamCount,
-        $0.3
-      ) },
+      namedImplicitsWrappers: namedImplicitsWrappers,
       publicInterface: publicInterface,
       testableInterface: testableInterface,
       implicitFunctions: implicitFunctions
@@ -645,7 +640,12 @@ extension UnresolvedGraph {
       )
       innerState.endLocalScope(at: sema.syntax, diagnostics: &diagnostics)
       traverseCodeBlock(body, state: &innerState)
-    case let .withNamedImplicits(wrapperName: name, closureParamCount: paramCount, body: body):
+    case let .withNamedImplicits(
+      wrapperName: name,
+      closureParamCount: paramCount,
+      effects: effects,
+      body: body
+    ):
       diagnostics.check(state.hasScope, or: .noScope, at: sema.syntax)
 
       var innerState = state
@@ -656,7 +656,13 @@ extension UnresolvedGraph {
       case .none:
         seenWrapperNames[name] = sema.syntax
         let wrapperNode = addNode(syntax: sema.syntax, parent: state.parent)
-        namedImplicitsWrappers.append((name, paramCount, wrapperNode, state.file))
+        namedImplicitsWrappers.append(ReqGraph.WrapperInfo(
+          wrapperName: name,
+          closureParamCount: paramCount,
+          effects: effects,
+          resolution: wrapperNode,
+          file: state.file
+        ))
         innerState.parent = wrapperNode
       case let .some(previousUsage?):
         diagnostics.diagnose(.duplicateWrapperName(name), at: sema.syntax)

--- a/Sources/ImplicitsTool/SemaTree.swift
+++ b/Sources/ImplicitsTool/SemaTree.swift
@@ -74,7 +74,9 @@ enum SemaTree<Syntax> {
     case implicitScopeBegin(nested: Bool, withBag: Bool)
     case implicitScopeEnd
     case withScope(nested: Bool, withBag: Bool, body: [CodeBlockItem])
-    case withNamedImplicits(wrapperName: String, closureParamCount: Int, body: [CodeBlockItem])
+    case withNamedImplicits(
+      wrapperName: String, closureParamCount: Int, effects: ClosureEffects, body: [CodeBlockItem]
+    )
     case implicitMap(from: ImplicitKey, to: ImplicitKey)
     case implicit(Implicit)
     case unresolvedIfConfigBlock(condition: Syntax, body: [CodeBlockItem])
@@ -250,10 +252,16 @@ extension SemaTree.CodeBlockItemNode {
       .implicit(implicit)
     case let .withScope(nested: nested, withBag: withBag, body: body):
       .withScope(nested: nested, withBag: withBag, body: body.map { $0.mapSyntax(transform) })
-    case let .withNamedImplicits(wrapperName: name, closureParamCount: count, body: body):
+    case let .withNamedImplicits(
+      wrapperName: name,
+      closureParamCount: count,
+      effects: effects,
+      body: body
+    ):
       .withNamedImplicits(
         wrapperName: name,
         closureParamCount: count,
+        effects: effects,
         body: body.map { $0.mapSyntax(transform) }
       )
     case let .implicitMap(from: from, to: to):

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -832,6 +832,7 @@ enum SemaTreeBuilder<
     // withFooImplicits { scope in ... }
     if let (wrapperName, closureParamCount, closure, scopeArg) = functionCall
       .isWithNamedImplicits() {
+      let effects = ClosureEffects(isAsync: closure.isAsync, isThrowing: closure.isThrowing)
       let body = visit(
         codeBlockEntities: closure.body,
         context: &context[withScope: closure, scopeParamter: scopeArg]
@@ -842,6 +843,7 @@ enum SemaTreeBuilder<
           node: .withNamedImplicits(
             wrapperName: wrapperName,
             closureParamCount: closureParamCount,
+            effects: effects,
             body: body
           )
         )

--- a/Sources/ImplicitsTool/SupportFile.swift
+++ b/Sources/ImplicitsTool/SupportFile.swift
@@ -20,6 +20,7 @@ public struct SupportFile {
   public struct NamedImplicitsWrapper {
     public var wrapperName: String
     public var closureParamCount: Int
+    public var effects: ClosureEffects
     public var requirements: [ImplicitKey]
   }
 

--- a/Sources/ImplicitsTool/SupportFileBuilder.swift
+++ b/Sources/ImplicitsTool/SupportFileBuilder.swift
@@ -3,6 +3,7 @@
 enum SupportFileBuilder<Syntax> {
   typealias Diagnostics = DiagnosticsGeneric<Syntax>
   typealias SyntaxTreeFile = (name: String, content: [SyntaxTree<SyntaxInfo>.TopLevelEntity])
+  typealias ResolvedWrapperInfo = WrapperInfo<[ImplicitKey], SyntaxTreeFile>
 
   private typealias ImplicitParameter = SupportFile.ImplicitParameter
 
@@ -14,12 +15,7 @@ enum SupportFileBuilder<Syntax> {
     semaTrees: [[SemaTree<Syntax>.TopLevel]],
     implicitFunctions: [(SemaTree<Syntax>.FuncDecl, SyntaxTreeFile, [ImplicitKey])],
     bags: [(name: String, requirements: [ImplicitKey], file: SyntaxTreeFile)],
-    namedImplicitsWrappers: [(
-      wrapperName: String,
-      closureParamCount: Int,
-      requirements: [ImplicitKey],
-      file: SyntaxTreeFile
-    )],
+    namedImplicitsWrappers: [ResolvedWrapperInfo],
     enableExporting: Bool,
     dependencies: [ImplicitModuleInterface],
     diagnostics: inout Diagnostics,
@@ -135,15 +131,16 @@ enum SupportFileBuilder<Syntax> {
       imports.registerImports(from: file, blame: "bags")
     }
 
-    for (_, _, _, file) in namedImplicitsWrappers {
-      imports.registerImports(from: file, blame: "named implicits wrappers")
+    for wrapper in namedImplicitsWrappers {
+      imports.registerImports(from: wrapper.file, blame: "named implicits wrappers")
     }
 
     let wrappers = namedImplicitsWrappers.map {
       SupportFile.NamedImplicitsWrapper(
         wrapperName: $0.wrapperName,
         closureParamCount: $0.closureParamCount,
-        requirements: $0.requirements
+        effects: $0.effects,
+        requirements: $0.resolution
       )
     }
 

--- a/Sources/ImplicitsTool/SupportFileRendering.swift
+++ b/Sources/ImplicitsTool/SupportFileRendering.swift
@@ -154,22 +154,26 @@ extension SupportFile {
         }
       }
 
-      let closureParamTypes: [String] = (0..<wrapper.closureParamCount)
-        .map { "A\($0 + 1)" } + ["ImplicitScope"]
-      let closureType = "(\(closureParamTypes.joined(separator: ", "))) -> T"
+      let closureType = FunctionTypeSyntax.wrapperType(
+        paramCount: wrapper.closureParamCount,
+        extraParam: "ImplicitScope",
+        effects: wrapper.effects
+      )
 
-      let returnParamTypes: [String] = (0..<wrapper.closureParamCount).map { "A\($0 + 1)" }
-      let returnType = returnParamTypes.isEmpty ? "() -> T" : "(\(returnParamTypes.joined(separator: ", "))) -> T"
+      let returnType = FunctionTypeSyntax.wrapperType(
+        paramCount: wrapper.closureParamCount,
+        effects: wrapper.effects
+      )
 
       let funcSignature = FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax(parameters: [
           FunctionParameterSyntax(
             firstName: "_",
             secondName: "body",
-            type: "@escaping \(raw: closureType)" as TypeSyntax
+            type: closureType.escaping()
           ),
         ]),
-        returnClause: ReturnClauseSyntax(type: "\(raw: returnType)" as TypeSyntax)
+        returnClause: ReturnClauseSyntax(type: returnType)
       )
 
       let funcName =
@@ -208,12 +212,14 @@ extension SupportFile {
             DeferStmtSyntax {
               FunctionCallExprSyntax(callee: "scope.end" as ExprSyntax)
             }
-            ReturnStmtSyntax(expression: FunctionCallExprSyntax(callee: "body" as ExprSyntax) {
-              for argName in argNames {
-                LabeledExprSyntax(expression: "\(raw: argName)" as ExprSyntax)
+            ReturnStmtSyntax(expression: wrapper.effects.wrapCall(
+              FunctionCallExprSyntax(callee: "body" as ExprSyntax) {
+                for argName in argNames {
+                  LabeledExprSyntax(expression: "\(raw: argName)" as ExprSyntax)
+                }
+                LabeledExprSyntax(expression: "scope" as ExprSyntax)
               }
-              LabeledExprSyntax(expression: "scope" as ExprSyntax)
-            })
+            ))
           }
         ))
       }
@@ -464,5 +470,38 @@ extension String {
     } else {
       self
     }
+  }
+}
+
+extension FunctionTypeSyntax {
+  static func wrapperType(
+    paramCount: Int,
+    extraParam: TokenSyntax? = nil,
+    effects: ClosureEffects
+  ) -> FunctionTypeSyntax {
+    FunctionTypeSyntax(
+      parameters: TupleTypeElementListSyntax {
+        for i in 0..<paramCount {
+          TupleTypeElementSyntax(type: IdentifierTypeSyntax(name: "A\(raw: i + 1)"))
+        }
+        if let extraParam {
+          TupleTypeElementSyntax(type: IdentifierTypeSyntax(name: extraParam))
+        }
+      },
+      effectSpecifiers: effects.effectSpecifiers,
+      returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: "T"))
+    )
+  }
+}
+
+extension TypeSyntaxProtocol {
+  func escaping() -> AttributedTypeSyntax {
+    AttributedTypeSyntax(
+      specifiers: [],
+      attributes: AttributeListSyntax {
+        AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("escaping")))
+      },
+      baseType: self
+    )
   }
 }

--- a/Sources/TestResources/test_data/support_file.swift
+++ b/Sources/TestResources/test_data/support_file.swift
@@ -44,6 +44,24 @@ private func withImplicits(_: ImplicitScope) {
     _ = a; _ = b
     requires(scope)
   }
+
+  // Async wrapper
+  _ = withAsyncImplicits { scope in
+    await asyncFunc()
+    requires(scope)
+  }
+
+  // Throwing wrapper
+  _ = withThrowingImplicits { scope in
+    try throwingFunc()
+    requires(scope)
+  }
+
+  // Async throwing wrapper
+  _ = withAsyncThrowingImplicits { scope in
+    try await asyncThrowingFunc()
+    requires(scope)
+  }
 }
 
 @_spi(Implicits)
@@ -129,3 +147,8 @@ private func requires(_: ImplicitScope) {
   @Implicit()
   var a2: UInt16
 }
+
+// Helper stubs for effect testing
+private func asyncFunc() async {}
+private func throwingFunc() throws {}
+private func asyncThrowingFunc() async throws {}

--- a/Sources/TestResources/test_data/support_file_snapshot.swift
+++ b/Sources/TestResources/test_data/support_file_snapshot.swift
@@ -28,7 +28,7 @@ internal func __implicit_bag_support_file_swift_28_22() -> Implicits {
   Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
 }
 
-internal func __implicit_bag_support_file_swift_62_19() -> Implicits {
+internal func __implicit_bag_support_file_swift_80_19() -> Implicits {
   Implicits()
 }
 
@@ -62,6 +62,39 @@ internal func withSupportTwoImplicits<T, A1, A2>(_ body: @escaping (A1, A2, Impl
       scope.end()
     }
     return body(arg1, arg2, scope)
+  }
+}
+
+internal func withAsyncImplicits<T>(_ body: @escaping (ImplicitScope) async -> T) -> () async -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return await body(scope)
+  }
+}
+
+internal func withThrowingImplicits<T>(_ body: @escaping (ImplicitScope) throws -> T) -> () throws -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return try body(scope)
+  }
+}
+
+internal func withAsyncThrowingImplicits<T>(_ body: @escaping (ImplicitScope) async throws -> T) -> () async throws -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return try await body(scope)
   }
 }
 

--- a/Tests/ImplicitsTests/ImplicitConcurrencyTests.swift
+++ b/Tests/ImplicitsTests/ImplicitConcurrencyTests.swift
@@ -62,7 +62,7 @@ struct ImplicitConcurrencyTests {
     let retrieved = await testMainActor(id: 81)
     #expect(retrieved == 81)
   }
-  
+
   @Test func childTasksScopesShouldBeIsolated() async {
     let cp = Checkpoint<Step>()
 


### PR DESCRIPTION
## Summary
- Closure effects (async/throws) are now extracted from `withNamedImplicits` closures and propagated through the analysis pipeline
- Generated wrapper functions include correct effect specifiers in both closure parameter and return types
- Refactored `namedImplicitsWrappers` from 5-element tuples into a generic `WrapperInfo<Resolution, File>` struct for better type safety and readability

## Test plan
- [x] All 106 existing tests pass
- [x] Added test cases for `withAsyncImplicits`, `withThrowingImplicits`, and `withAsyncThrowingImplicits` in support_file.swift
- [x] Verified generated output in support_file_snapshot.swift