### PR TITLE
Add SwiftFormat pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,14 @@ Similar patterns in other languages:
 - **Scala** — `given`/`using` (formerly implicit parameters)
 - **Kotlin** — Context receivers
 
+## Development
+
+To set up the pre-commit hook for SwiftFormat:
+
+```bash
+./scripts/setup-hooks.sh
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1566,7 +1566,6 @@ extension Diagnostic.Location {
   }
 }
 
-
 // TODO: To base
 extension String {
   public init(_ staticString: StaticString) {

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.swift$')
+
+if [ -z "$STAGED_FILES" ]; then
+  exit 0
+fi
+
+if ! command -v swiftformat &> /dev/null; then
+  echo "error: swiftformat not installed. Install with: brew install swiftformat"
+  exit 1
+fi
+
+if ! swiftformat --lint $STAGED_FILES; then
+  echo ""
+  echo "Fix with: swiftformat ."
+  exit 1
+fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [ ! -d "$REPO_ROOT/.git" ] && [ "$REPO_ROOT" != "/" ]; do
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+
+if [ ! -d "$REPO_ROOT/.git" ]; then
+  echo "error: not a git repository"
+  exit 1
+fi
+
+if [ ! -x "$SCRIPT_DIR/pre-commit" ]; then
+  echo "error: pre-commit hook not found or not executable"
+  exit 1
+fi
+
+ln -sf "$SCRIPT_DIR/pre-commit" "$REPO_ROOT/.git/hooks/pre-commit"
+echo "Pre-commit hook installed"


### PR DESCRIPTION
## Summary
- Add `scripts/pre-commit` hook that runs SwiftFormat on staged Swift files
- Add `scripts/setup-hooks.sh` for easy hook installation
- Add Development section to README with setup instructions

Developers can install the hook with:
```bash
./scripts/setup-hooks.sh
```