### PR TITLE
Skip iOS tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
         run: swift build --target ShowcaseDependency --enable-experimental-prebuilts
 
       - name: Test Implicits for iOS
+        if: github.event_name == 'push'
         run: swift test --filter ImplicitsTests --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios14.0-simulator --enable-experimental-prebuilts


### PR DESCRIPTION
## Summary
- Skip iOS tests on PRs to speed up CI (saves 75-120 sec)
- iOS tests still run on push to main after merge

Addresses #33