### PR TITLE
Support parenthesized #withImplicits syntax

### DIFF
--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1023,12 +1023,14 @@ enum SemaTreeBuilder<
     syntax: Syntax,
     context: inout Context
   ) -> [CodeBlockItem] {
-    guard macro.name == ImplicitKeyword.Macro.withImplicits,
-          let trailingClosure = macro.trailingClosure else {
+    guard
+      macro.name == ImplicitKeyword.Macro.withImplicits,
+      let closureEntity = macro.singleClosureArgument
+    else {
       return []
     }
 
-    let closure = trailingClosure.value
+    let closure = closureEntity.value
     guard let params = closure.parameters, !params.isEmpty else {
       context.diagnose(.withImplicitsRequiresClosureWithScope, at: syntax)
       return []
@@ -1513,6 +1515,18 @@ extension SyntaxTree.FunctionCall {
 extension SyntaxTree.ClosureParameter {
   var isImplicitScope: Bool {
     name.value.isWildcard || name.value.literal == ImplicitKeyword.Scope.variableName
+  }
+}
+
+extension SyntaxTree.MacroExpansion {
+  var singleClosureArgument: SyntaxTree.Entity<SyntaxTree.ClosureExpr>? {
+    if let trailing = trailingClosure {
+      return trailing
+    }
+    if let arg = arguments.singleElement, case let .closure(expr) = arg.value {
+      return .init(value: expr, syntax: arg.syntax)
+    }
+    return nil
   }
 }
 

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -162,6 +162,7 @@ public enum SyntaxTree<Syntax> {
 
   public struct MacroExpansion {
     public var name: String
+    public var arguments: [Entity<Expression>]
     public var trailingClosure: Entity<ClosureExpr>?
   }
 
@@ -774,6 +775,7 @@ extension SyntaxTree.MacroExpansion {
   func mapSyntax<S>(_ t: (Syntax) -> S) -> SyntaxTree<S>.MacroExpansion {
     .init(
       name: name,
+      arguments: arguments.map { $0.map(t, ST.Expression.mapSyntax) },
       trailingClosure: trailingClosure?.map(t, ST.ClosureExpr.mapSyntax)
     )
   }

--- a/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
@@ -437,6 +437,12 @@ extension ExprSyntax: SyntaxDescriptionProvider {
     case let .macroExpansionExpr(e):
       .macroExpansion(.init(
         name: e.macroName.text,
+        arguments: e.arguments.map { arg in
+          .init(
+            value: arg.expression.syntaxDescription(context: context),
+            syntax: Syntax(arg.expression)
+          )
+        },
         trailingClosure: e.trailingClosure.map {
           .init(
             value: $0.syntaxDescription(context: context),
@@ -494,6 +500,12 @@ extension MacroExpansionExprSyntax: SyntaxDescriptionProvider {
   fileprivate func syntaxDescription(context: Context) -> SXT.MacroExpansion {
     .init(
       name: macroName.text,
+      arguments: arguments.map { arg in
+        .init(
+          value: arg.expression.syntaxDescription(context: context),
+          syntax: Syntax(arg.expression)
+        )
+      },
       trailingClosure: trailingClosure.map {
         .init(
           value: $0.syntaxDescription(context: context),

--- a/Sources/TestResources/test_data/with_implicits_macro.swift
+++ b/Sources/TestResources/test_data/with_implicits_macro.swift
@@ -33,7 +33,34 @@ private func underscoreScope() {
   }
 }
 
+private func parenthesizedSyntax() {
+  // expected-error@+1 {{Unresolved requirement: Int16}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  _ = #withImplicits({ scope in
+    @Implicit() var v1: Int16
+  })
+}
+
+// Type inference fails for macro-expanded closures with capture lists
+// https://github.com/swiftlang/swift/issues/86871
+#if NO_COMPILE
+private func withCaptureList() {
+  // expected-error@+1 {{Unresolved requirement: Int32}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  let x = 42
+  _ = #withImplicits { [x] scope in
+    @Implicit() var v1: Int32
+    return x
+  }
+}
+#endif
+
 private func __implicit_wrap_with_implicits_macro_swift_9_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_13_7<A1, A2, T>(_ body: @escaping (A1, A2, ImplicitScope) -> T) -> (A1, A2) -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_21_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_31_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+private func __implicit_wrap_with_implicits_macro_swift_41_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }

--- a/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
+++ b/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
@@ -36,4 +36,45 @@ struct ImplicitMacroTests {
       macros: testMacros
     )
   }
+
+  @Test func withImplicitsMacroParenthesizedSyntax() {
+    assertMacroExpansion(
+      """
+      let c = #withImplicits({ _ in 42 })
+      """,
+      expandedSource: """
+      let c = __implicit_wrap_test_swift_1_9({ _ in 42 })
+      """,
+      diagnostics: [],
+      macros: testMacros
+    )
+  }
+
+  @Test func withImplicitsMacroNonClosureArgument() {
+    assertMacroExpansion(
+      """
+      let c = #withImplicits(someVariable)
+      """,
+      expandedSource: """
+      let c = #withImplicits(someVariable)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "#withImplicits requires a closure argument", line: 1, column: 9)
+      ],
+      macros: testMacros
+    )
+  }
+
+  @Test func withImplicitsMacroWithCaptureList() {
+    assertMacroExpansion(
+      """
+      let c = #withImplicits({ [weak self] scope in 42 })
+      """,
+      expandedSource: """
+      let c = __implicit_wrap_test_swift_1_9({ [weak self] scope in 42 })
+      """,
+      diagnostics: [],
+      macros: testMacros
+    )
+  }
 }


### PR DESCRIPTION
## Summary

- Add support for `#withImplicits({ closure })` parenthesized syntax in static analysis
- Add `arguments` field to `MacroExpansion` syntax tree node

## Test plan

- [x] All existing tests pass
- [x] Static analysis test for parenthesized syntax