### PR TITLE
Detect nested macro expansion and improve diagnostics

### DIFF
--- a/Sources/ImplicitsMacros/ImplicitsMacros.swift
+++ b/Sources/ImplicitsMacros/ImplicitsMacros.swift
@@ -1,6 +1,5 @@
 // Copyright 2023 Yandex LLC. All rights reserved.
 
-import Foundation
 import ImplicitsShared
 import MacroUtils
 import SwiftCompilerPlugin
@@ -15,6 +14,7 @@ public struct ImplicitMacro: ExpressionMacro {
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
     let loc = try SourceLocation(of: node, in: context)
+    try loc.checkNotInMacroExpansion("implicits")
     let funcName = generateImplicitBagFuncName(
       filename: loc.fileName,
       line: loc.line,
@@ -30,6 +30,7 @@ public struct WithImplicitsMacro: ExpressionMacro {
     in context: some MacroExpansionContext
   ) throws -> ExprSyntax {
     let loc = try SourceLocation(of: node, in: context)
+    try loc.checkNotInMacroExpansion("withImplicits")
 
     // Get the closure argument (either as argument or trailing closure)
     let closure: ClosureExprSyntax

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1729,5 +1729,5 @@ extension DiagnosticMessage {
   fileprivate static let withImplicitsRequiresClosureWithScope: Self =
     "#withImplicits requires a closure with at least a scope parameter"
   fileprivate static let withImplicitsLastParamMustBeScope: Self =
-    "#withImplicits closure's last parameter must be of type ImplicitScope"
+    "#withImplicits closure's last parameter must be named 'scope' or '_'"
 }

--- a/Sources/MacroUtils/SourceLocation.swift
+++ b/Sources/MacroUtils/SourceLocation.swift
@@ -2,13 +2,18 @@ import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
 
-package struct SourceLocation {
+package struct SourceLocation<Node: FreestandingMacroExpansionSyntax> {
   package var fileName: String
   package var line: String
   package var column: String
+  private var node: Node
+
+  private var isInMacroExpansion: Bool {
+    fileName.hasPrefix("@__swiftmacro_")
+  }
 
   package init(
-    of node: some FreestandingMacroExpansionSyntax,
+    of node: Node,
     in context: some MacroExpansionContext
   ) throws {
     guard let loc = context.location(of: node),
@@ -19,9 +24,16 @@ package struct SourceLocation {
     guard let lastComponent = moduleAndFile.last else {
       throw DiagnosticsError.at(node, "Unable to get file name")
     }
+    self.node = node
     self.fileName = String(lastComponent)
     self.line = loc.line.trimmedDescription
     self.column = loc.column.trimmedDescription
+  }
+
+  package func checkNotInMacroExpansion(_ macroName: String) throws {
+    if isInMacroExpansion {
+      throw DiagnosticsError.at(node, "#\(macroName) cannot be used inside macro expansion")
+    }
   }
 }
 

--- a/Sources/TestResources/test_data/with_implicits_macro.swift
+++ b/Sources/TestResources/test_data/with_implicits_macro.swift
@@ -43,9 +43,19 @@ private func parenthesizedSyntax() {
   })
 }
 
+private func customScopeName() {
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  // expected-error@+1 {{#withImplicits closure's last parameter must be named 'scope' or '_'}}
+  _ = #withImplicits { myScope in
+    @Implicit() var v1: Int16
+  }
+}
+
+#if NO_COMPILE
 // Type inference fails for macro-expanded closures with capture lists
 // https://github.com/swiftlang/swift/issues/86871
-#if NO_COMPILE
 private func withCaptureList() {
   // expected-error@+1 {{Unresolved requirement: Int32}}
   let scope = ImplicitScope()
@@ -64,3 +74,5 @@ private func __implicit_wrap_with_implicits_macro_swift_13_7<A1, A2, T>(_ body: 
 private func __implicit_wrap_with_implicits_macro_swift_21_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_31_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_41_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+private func __implicit_wrap_with_implicits_macro_swift_51_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+private func __implicit_wrap_with_implicits_macro_swift_65_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }


### PR DESCRIPTION
## Summary
- Detect when `#implicits` or `#withImplicits` macros are used inside another macro expansion and emit clear error message
- Improve `#withImplicits` diagnostic from misleading "must be of type ImplicitScope" to accurate "must be named 'scope' or '_'"
- Remove unused Foundation import

## Test plan
- [x] Existing tests pass (113 tests)
- [x] Added test for custom scope name validation in `with_implicits_macro.swift`