### PR TITLE
Document macro limitations and add docs index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 @AGENTS.md
+
+## Documentation
+
+@docs/index.md

--- a/docs/closures.md
+++ b/docs/closures.md
@@ -74,6 +74,11 @@ The macro automatically infers `async` and `throws` from the closure body:
 #withImplicits { scope async throws in ... }
 ```
 
+### Limitations
+
+- **No capture lists:** Due to a [Swift compiler bug](https://github.com/swiftlang/swift/issues/86871), closures with capture lists like `[weak self]` won't compile. Use [Named Wrappers](#named-wrappers-withNameimplicits) instead.
+- **No nested macro usage:** `#withImplicits` and `#implicits` cannot be used inside another macro expansion. Source locations inside macro-generated code resolve to synthetic contexts that the static analyzer cannot correlate with macro-generated function names.
+
 ## Named Wrappers: `with${Name}Implicits`
 
 If your project prefers not to use macros, you can use wrapper functions that follow a naming convention. The analyzer recognizes functions matching `with${Name}Implicits`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Documentation
+
+- [Working with Closures](closures.md) - Passing implicits through closures using `#withImplicits`, named wrappers, and `#implicits`


### PR DESCRIPTION
## Summary
- Add limitations section to closures guide: capture list Swift bug and nested macro expansion restriction
- Add `docs/index.md` as documentation entry point
- Reference docs index from `CLAUDE.md`

## Test plan
- Documentation-only change, no code affected