### PR TITLE
Support closure type attributes in named implicits wrappers

### DIFF
--- a/Sources/ImplicitsTool/ClosureEffects.swift
+++ b/Sources/ImplicitsTool/ClosureEffects.swift
@@ -2,12 +2,22 @@
 
 import SwiftSyntax
 
-/// Represents the effects (async/throwing) of a closure used in named implicits wrappers.
-public struct ClosureEffects: Equatable, Sendable {
+/// Represents the effects (async/throwing) and type attributes of a closure used in named
+/// implicits wrappers.
+public struct ClosureEffects<Syntax> {
   public var isAsync: Bool
   public var isThrowing: Bool
+  public var typeAttributes: [SyntaxTree<Syntax>.TypeModel]
 
-  static let none = Self(isAsync: false, isThrowing: false)
+  static var none: Self { Self(isAsync: false, isThrowing: false, typeAttributes: []) }
+
+  var typeAttributesSyntax: AttributeListSyntax {
+    AttributeListSyntax {
+      for typeModel in typeAttributes {
+        AttributeSyntax(attributeName: TypeSyntax("\(raw: typeModel.description)"))
+      }
+    }
+  }
 
   /// Returns effect specifiers syntax for use in function types.
   var effectSpecifiers: TypeEffectSpecifiersSyntax? {
@@ -28,5 +38,13 @@ public struct ClosureEffects: Equatable, Sendable {
       expr = ExprSyntax(TryExprSyntax(expression: expr))
     }
     return expr
+  }
+
+  func mapSyntax<S>(_ transform: (Syntax) -> S) -> ClosureEffects<S> {
+    ClosureEffects<S>(
+      isAsync: isAsync,
+      isThrowing: isThrowing,
+      typeAttributes: typeAttributes.map { $0.mapSyntax(transform) }
+    )
   }
 }

--- a/Sources/ImplicitsTool/RequirementsGraph.swift
+++ b/Sources/ImplicitsTool/RequirementsGraph.swift
@@ -12,7 +12,7 @@ public struct RequirementsGraph<Syntax, File> {
     }
   }
 
-  typealias WrapperInfo<Resolution> = ImplicitsTool.WrapperInfo<Resolution, File>
+  typealias WrapperInfo<Resolution> = ImplicitsTool.WrapperInfo<Resolution, File, Syntax>
 
   typealias Graph = OrderedGraph<Node, Void>
   var graph: Graph
@@ -129,10 +129,10 @@ extension DiagnosticMessage {
   }
 }
 
-struct WrapperInfo<Resolution, File> {
+struct WrapperInfo<Resolution, File, Syntax> {
   var wrapperName: String
   var closureParamCount: Int
-  var effects: ClosureEffects
+  var effects: ClosureEffects<Syntax>
   var resolution: Resolution
   var file: File
 }

--- a/Sources/ImplicitsTool/SemaTree.swift
+++ b/Sources/ImplicitsTool/SemaTree.swift
@@ -75,7 +75,8 @@ enum SemaTree<Syntax> {
     case implicitScopeEnd
     case withScope(nested: Bool, withBag: Bool, body: [CodeBlockItem])
     case withNamedImplicits(
-      wrapperName: String, closureParamCount: Int, effects: ClosureEffects, body: [CodeBlockItem]
+      wrapperName: String, closureParamCount: Int,
+      effects: ClosureEffects<Syntax>, body: [CodeBlockItem]
     )
     case implicitMap(from: ImplicitKey, to: ImplicitKey)
     case implicit(Implicit)
@@ -261,7 +262,7 @@ extension SemaTree.CodeBlockItemNode {
       .withNamedImplicits(
         wrapperName: name,
         closureParamCount: count,
-        effects: effects,
+        effects: effects.mapSyntax(transform),
         body: body.map { $0.mapSyntax(transform) }
       )
     case let .implicitMap(from: from, to: to):

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -832,7 +832,11 @@ enum SemaTreeBuilder<
     // withFooImplicits { scope in ... }
     if let (wrapperName, closureParamCount, closure, scopeArg) = functionCall
       .isWithNamedImplicits() {
-      let effects = ClosureEffects(isAsync: closure.isAsync, isThrowing: closure.isThrowing)
+      let effects = ClosureEffects(
+        isAsync: closure.isAsync,
+        isThrowing: closure.isThrowing,
+        typeAttributes: closure.typeAttributes
+      )
       let body = visit(
         codeBlockEntities: closure.body,
         context: &context[withScope: closure, scopeParamter: scopeArg]
@@ -1046,7 +1050,11 @@ enum SemaTreeBuilder<
     // closureParamCount is all params except the scope
     let closureParamCount = params.count - 1
 
-    let effects = ClosureEffects(isAsync: closure.isAsync, isThrowing: closure.isThrowing)
+    let effects = ClosureEffects(
+      isAsync: closure.isAsync,
+      isThrowing: closure.isThrowing,
+      typeAttributes: closure.typeAttributes
+    )
     let body = visit(
       codeBlockEntities: closure.body,
       context: &context[withScope: closure, scopeParamter: lastParam.name.syntax]

--- a/Sources/ImplicitsTool/SupportFile.swift
+++ b/Sources/ImplicitsTool/SupportFile.swift
@@ -20,7 +20,7 @@ public struct SupportFile {
   public struct NamedImplicitsWrapper {
     public var wrapperName: String
     public var closureParamCount: Int
-    public var effects: ClosureEffects
+    public var effects: ClosureEffects<Void>
     public var requirements: [ImplicitKey]
   }
 

--- a/Sources/ImplicitsTool/SupportFileBuilder.swift
+++ b/Sources/ImplicitsTool/SupportFileBuilder.swift
@@ -3,7 +3,7 @@
 enum SupportFileBuilder<Syntax> {
   typealias Diagnostics = DiagnosticsGeneric<Syntax>
   typealias SyntaxTreeFile = (name: String, content: [SyntaxTree<SyntaxInfo>.TopLevelEntity])
-  typealias ResolvedWrapperInfo = WrapperInfo<[ImplicitKey], SyntaxTreeFile>
+  typealias ResolvedWrapperInfo = WrapperInfo<[ImplicitKey], SyntaxTreeFile, Syntax>
 
   private typealias ImplicitParameter = SupportFile.ImplicitParameter
 
@@ -139,7 +139,7 @@ enum SupportFileBuilder<Syntax> {
       SupportFile.NamedImplicitsWrapper(
         wrapperName: $0.wrapperName,
         closureParamCount: $0.closureParamCount,
-        effects: $0.effects,
+        effects: $0.effects.mapSyntax { _ in },
         requirements: $0.resolution
       )
     }

--- a/Sources/ImplicitsTool/SupportFileRendering.swift
+++ b/Sources/ImplicitsTool/SupportFileRendering.swift
@@ -154,16 +154,18 @@ extension SupportFile {
         }
       }
 
+      let typeAttrs = wrapper.effects.typeAttributesSyntax
+
       let closureType = FunctionTypeSyntax.wrapperType(
         paramCount: wrapper.closureParamCount,
         extraParam: "ImplicitScope",
         effects: wrapper.effects
-      )
+      ).withTypeAttributes(typeAttrs)
 
       let returnType = FunctionTypeSyntax.wrapperType(
         paramCount: wrapper.closureParamCount,
         effects: wrapper.effects
-      )
+      ).withTypeAttributes(typeAttrs)
 
       let funcSignature = FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax(parameters: [
@@ -474,7 +476,7 @@ extension FunctionTypeSyntax {
   static func wrapperType(
     paramCount: Int,
     extraParam: TokenSyntax? = nil,
-    effects: ClosureEffects
+    effects: ClosureEffects<Void>
   ) -> FunctionTypeSyntax {
     FunctionTypeSyntax(
       parameters: TupleTypeElementListSyntax {
@@ -492,6 +494,14 @@ extension FunctionTypeSyntax {
 }
 
 extension TypeSyntaxProtocol {
+  func withTypeAttributes(_ attrs: AttributeListSyntax) -> AttributedTypeSyntax {
+    AttributedTypeSyntax(
+      specifiers: [],
+      attributes: attrs,
+      baseType: self
+    )
+  }
+
   func escaping() -> AttributedTypeSyntax {
     AttributedTypeSyntax(
       specifiers: [],

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -200,6 +200,7 @@ public enum SyntaxTree<Syntax> {
     public var captures: [Capture]?
     public var parameters: Parameters?
     public var body: [CodeBlockEntity]
+    public var typeAttributes: [TypeModel]
   }
 
   /// Represents defer statement
@@ -786,7 +787,8 @@ extension SyntaxTree.ClosureExpr {
     .init(
       captures: captures?.map { $0.map(t, ST.ClosureExpr.CaptureDescription.mapSyntax) },
       parameters: parameters?.map { $0.mapSyntax(t) },
-      body: body.map { $0.map(t, ST.CodeBlockStatement.mapSyntax) }
+      body: body.map { $0.map(t, ST.CodeBlockStatement.mapSyntax) },
+      typeAttributes: typeAttributes.map { $0.mapSyntax(t) }
     )
   }
 }

--- a/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
@@ -322,6 +322,13 @@ extension FunctionSignatureSyntax {
 }
 
 extension ClosureSignatureSyntax {
+  fileprivate func parsedTypeAttributes(context: Context) -> [SXT.TypeModel] {
+    attributes.compactMap { element -> SXT.TypeModel? in
+      guard case let .attribute(attribute) = element else { return nil }
+      return attribute.attributeName.parsedType(context: context)
+    }
+  }
+
   fileprivate func parsedParameters(
     context: Context
   ) -> [SXT.ClosureParameter]? {
@@ -407,7 +414,8 @@ extension ClosureExprSyntax: SyntaxDescriptionProvider {
     .init(
       captures: signature?.capture?.syntaxDescription(context: context),
       parameters: signature?.parsedParameters(context: context),
-      body: statements.syntaxDescription(context: context)
+      body: statements.syntaxDescription(context: context),
+      typeAttributes: signature?.parsedTypeAttributes(context: context) ?? []
     )
   }
 }

--- a/Sources/TestResources/test_data/support_file.swift
+++ b/Sources/TestResources/test_data/support_file.swift
@@ -63,6 +63,20 @@ private func withImplicits(_: ImplicitScope) {
     requires(scope)
   }
 
+  // @MainActor wrapper
+  _ = withMainActorImplicits { @MainActor scope in
+    requires(scope)
+  }
+
+  #if NO_COMPILE
+  // Generic closure wrappers lose type attributes,
+  // no way to parameterize over them.
+  // See https://forums.swift.org/t/84482
+  _ = #withImplicits { @MainActor scope in
+    requires(scope)
+  }
+  #endif
+
   // #withImplicits macro
   _ = #withImplicits { scope in
     requires(scope)

--- a/Sources/TestResources/test_data/support_file_snapshot.swift
+++ b/Sources/TestResources/test_data/support_file_snapshot.swift
@@ -28,7 +28,7 @@ internal func __implicit_bag_support_file_swift_28_22() -> Implicits {
   Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
 }
 
-internal func __implicit_bag_support_file_swift_91_19() -> Implicits {
+internal func __implicit_bag_support_file_swift_105_19() -> Implicits {
   Implicits()
 }
 
@@ -98,7 +98,7 @@ internal func withAsyncThrowingImplicits<T>(_ body: @escaping (ImplicitScope) as
   }
 }
 
-internal func __implicit_wrap_support_file_swift_67_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+internal func withMainActorImplicits<T>(_ body: @escaping @MainActor (ImplicitScope) -> T) -> @MainActor () -> T {
   let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
   return {
     let scope = ImplicitScope(with: implicits)
@@ -109,7 +109,29 @@ internal func __implicit_wrap_support_file_swift_67_7<T>(_ body: @escaping (Impl
   }
 }
 
-internal func __implicit_wrap_support_file_swift_72_7<T>(_ body: @escaping (ImplicitScope) async throws -> T) -> () async throws -> T {
+internal func __implicit_wrap_support_file_swift_75_7<T>(_ body: @escaping @MainActor (ImplicitScope) -> T) -> @MainActor () -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(scope)
+  }
+}
+
+internal func __implicit_wrap_support_file_swift_81_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(scope)
+  }
+}
+
+internal func __implicit_wrap_support_file_swift_86_7<T>(_ body: @escaping (ImplicitScope) async throws -> T) -> () async throws -> T {
   let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
   return {
     let scope = ImplicitScope(with: implicits)


### PR DESCRIPTION
## Summary
- Named wrappers now preserve closure type attributes (e.g. `@MainActor`) on both input and return function types
- Parsing extracts attributes from closure signatures, `ClosureEffects` carries them through semantic analysis, and `SupportFileRendering` applies them to generated code
- Documents the limitation that `#withImplicits` macro cannot support type attributes due to Swift's inability to parameterize generics over attributes (https://forums.swift.org/t/84482)

## Example

```swift
// Input
_ = withMainActorImplicits { @MainActor scope in
    requires(scope)
}

// Generated wrapper
func withMainActorImplicits<T>(
    _ body: @escaping @MainActor (ImplicitScope) -> T
) -> @MainActor () -> T { ... }
```

## Test plan
- [ ] Existing tests pass (`swift test`)
- [ ] Snapshot test updated with `withMainActorImplicits` wrapper output
- [ ] `#if NO_COMPILE` block documents macro limitation