### PR TITLE
Support immediate closure scope inheritance in static analysis

### DIFF
--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -854,6 +854,27 @@ enum SemaTreeBuilder<
       ])
     }
 
+    // Immediate closures: MainActor.assumeIsolated { ... }
+    // The trailing closure body inherits the current implicit scope
+    if let closure = functionCall.trailingClosure?.value,
+       context.isImmediateClosureCall(functionCall) {
+      let bodyNodes = visit(
+        codeBlockEntities: closure.body,
+        context: &context
+      )
+      let nested = nestedExpressions(
+        in: functionCall.arguments,
+        context: &context
+      ) + visit(
+        codeBlockEntities: functionCall.baseExprs,
+        context: &context
+      )
+      return .regularFunction(argsAndCalled: nested + .item(
+        .innerScope(bodyNodes),
+        at: functionCall.trailingClosure!.syntax
+      ))
+    }
+
     // ImplicitScope()
     if functionCall.isImplicitScopeInitializer {
       let hasBag = analyzeImplicitScopeArgs(
@@ -1518,6 +1539,7 @@ extension SyntaxTree.FunctionCall {
       scopeArg: lastParam.name.syntax
     )
   }
+
 }
 
 extension SyntaxTree.ClosureParameter {

--- a/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilderContext.swift
@@ -329,6 +329,18 @@ extension SemaTreeBuilder.Context {
       .isImplicitScope ?? false
   }
 
+  /// Returns `true` when the function call executes its trailing closure
+  /// immediately and the closure should inherit the current implicit scope
+  /// (e.g. `MainActor.assumeIsolated { ... }`).
+  func isImmediateClosureCall(_ call: SXT.FunctionCall) -> Bool {
+    guard call.trailingClosure != nil,
+          let base = call.base,
+          let funcName = call.name?.value.description else {
+      return false
+    }
+    return base.description == "MainActor" && funcName == "assumeIsolated"
+  }
+
   // MARK: - parsing time registration
 
   mutating func registerDeclaration(_ item: SXT.Declaration) {

--- a/Sources/TestResources/test_data/immediate_closure.swift
+++ b/Sources/TestResources/test_data/immediate_closure.swift
@@ -1,0 +1,41 @@
+import Implicits
+
+private func immediateClosureUsage() {
+  // expected-error@+1 {{Unresolved requirements: UInt16, UInt64, UInt8}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  MainActor.assumeIsolated {
+    @Implicit() var v1: UInt8
+    @Implicit() var v2: UInt16
+  }
+
+  MainActor.assumeIsolated {
+    let scope = scope.nested()
+    defer { scope.end() }
+
+    @Implicit() var v1: UInt32 = 0
+    requireUInt32(scope)
+    requireUInt64(scope)
+  }
+}
+
+private func explicitCaptureOnImmediateClosure() {
+  // expected-error@+1 {{Unresolved requirement: UInt32}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  MainActor.assumeIsolated(withCapturedImplicits { scope in
+    @Implicit() var v1: UInt32
+  })
+}
+
+private func requireUInt32(_: ImplicitScope) {
+  @Implicit() var v1: UInt32
+}
+
+private func requireUInt64(_: ImplicitScope) {
+  @Implicit() var v1: UInt64
+}
+
+private func withCapturedImplicits<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }

--- a/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
+++ b/Tests/ImplicitsToolTests/StaticAnalysisTests.swift
@@ -118,6 +118,10 @@ struct StaticAnalysisTests {
   @Test func ifConfigCodeBlock() {
     verify(file: "if_config_code_block.swift", compilationConditions: ["A", "B", "C"])
   }
+
+  @Test func immediateClosure() {
+    verify(file: "immediate_closure.swift")
+  }
 }
 
 private let anotherModule = (modulename: "AnotherModule", files: ["another_module.swift"])


### PR DESCRIPTION
## Summary
- `MainActor.assumeIsolated { ... }` trailing closures now inherit the enclosing implicit scope, so requirements propagate to the parent scope
- Detection logic lives in `Context.isImmediateClosureCall`, matching specifically on `MainActor.assumeIsolated` (base + name)
- Closure body is emitted as `.innerScope`, consistent with how `do` blocks and other inheriting scopes work

## Test plan
- [x] Basic immediate closure: implicit reads inside `MainActor.assumeIsolated` propagate as unresolved requirements
- [x] Nested scope inside immediate closure: `scope.nested()` works, locally satisfied requirements don't propagate
- [x] Explicit capture via named wrapper on immediate closure call still works (`MainActor.assumeIsolated(withFooImplicits { ... })`)
- [x] Full test suite passes (114 tests)

Related: #43 (multiple trailing closures not yet modeled)