### PR TITLE
Add Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "implicits",
+  "owner": {
+    "name": "Yandex"
+  },
+  "description": "Implicits — Swift library for implicit parameter passing through call stacks",
+  "plugins": [
+    {
+      "name": "implicits",
+      "source": "./",
+      "description": "AI guidance for working with the Implicits Swift library"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "implicits",
+  "description": "AI guidance for the Implicits Swift library — implicit parameter passing through call stacks. Bundles usage patterns, scope lifetime rules, closure handling, and static-analysis constraints so Claude generates correct code in projects using Implicits.",
+  "author": {
+    "name": "Yandex"
+  },
+  "homepage": "https://github.com/yandex/implicits",
+  "repository": "https://github.com/yandex/implicits"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Implicits is a Swift library for implicit parameter passing through call stacks,
 
 ## Usage Guide
 
-@AI_GUIDE.md
+@skills/implicits-usage-guide/SKILL.md
 
 ## Development Process
 
@@ -19,7 +19,7 @@ Every bug fix, feature, or implementation must follow these steps in order:
 
 If the test passes in step 2, either the bug doesn't exist or the test is wrong. The failing test tells you exactly what's broken and where. Without it, you're guessing — you'll waste time investigating why existing tests pass, make wrong assumptions, and "fix" things that weren't the problem.
 
-After implementing new features, keep `README.md` and `AI_GUIDE.md` up to date.
+After implementing new features, keep `README.md` and `skills/implicits-usage-guide/SKILL.md` up to date.
 
 ## Common Development Commands
 

--- a/skills/implicits-usage-guide/SKILL.md
+++ b/skills/implicits-usage-guide/SKILL.md
@@ -1,6 +1,11 @@
-# Implicits Usage Guide for AI Assistants
+---
+name: implicits-usage-guide
+description: Swift Implicits library — use for code with `@Implicit`, `ImplicitScope`, `#withImplicits`, `#implicits`, `withScope`, or a `Package.swift` depending on the `implicits` package.
+---
 
-This project uses Implicits - a Swift library for implicit parameter passing through call stacks. Eliminates "parameter drilling" - passing same arguments through multiple function layers.
+# Implicits Usage Guide
+
+Implicits is a Swift library for implicit parameter passing through call stacks — eliminates "parameter drilling" (passing the same arguments through many function layers). Similar in spirit to implicit parameters in Scala or context receivers in Kotlin.
 
 ## Core Pattern
 
@@ -21,15 +26,15 @@ func fetch(_ scope: ImplicitScope) {
 ```
 
 **Rules:**
-- `ImplicitScope` — last argument without parameter label
-- Always `defer { scope.end() }` after creating scope
+- `ImplicitScope` — last argument, no parameter label
+- Always `defer { scope.end() }` after creating a scope
 - Declaration: `@Implicit var x = value` (with initializer)
 - Retrieval: `@Implicit var x: Type` (no initializer, explicit type)
 - Missing implicit = compile-time error
 
 ## Keys: Type-Based vs Named
 
-**Type-based (default)** — type is the key:
+**Type-based (default)** — the type itself is the key:
 ```swift
 @Implicit var network: NetworkService
 ```
@@ -52,22 +57,27 @@ func inner(_ outer: ImplicitScope) async {
   let scope = outer.nested()
   defer { scope.end() }
 
-  @Implicit var extra = ExtraService()  // added in this scope
+  @Implicit var extra = ExtraService()
   await extra.doWork(scope)
 }
 ```
 
-Note: async code is supported.
+Async code is supported.
 
 ## Closures
 
-Closures don't inherit scope — `#withImplicits` captures implicits used in body:
+Closures don't inherit scope automatically. Use `#withImplicits` to capture implicits used in the body:
+
 ```swift
 fetchData(completion: #withImplicits { result, scope in
   @Implicit var handler: ResultHandler
   handler.process(result)
 })
 ```
+
+Effects (`async`/`throws`) are inferred. `@MainActor` is preserved on the result; other global actors aren't — use named wrappers for those.
+
+For full details on `#withImplicits`, named wrappers, capture lists, and `#implicits`, see `docs/closures.md` in the Implicits repo.
 
 ## Factory Pattern
 
@@ -88,7 +98,7 @@ class Component {
 
 ## Stored Properties in Types
 
-`@Implicit` works as stored property — type needs scope in initializer:
+`@Implicit` works as a stored property — the type needs a scope in its initializer:
 ```swift
 struct View {
   @Implicit var theme: Theme
@@ -97,18 +107,18 @@ struct View {
 }
 ```
 
-## Init/Defer Alternative
+## `withScope` Alternative
 
-`withScope` handles scope lifecycle. When indentation is not a problem and the body is fairly small:
+`withScope` handles scope lifecycle when indentation isn't a problem and the body is small:
 ```swift
-withScope { scope in ... }                    // Root scope
-withScope(with: implicits) { scope in ... }   // From captured implicits
-withScope(nesting: outer) { scope in ... }    // Nested scope
+withScope { scope in ... }                    // root scope
+withScope(with: implicits) { scope in ... }   // from captured implicits
+withScope(nesting: outer) { scope in ... }    // nested scope
 ```
 
 ## Build-Time Analysis Setup
 
-Add plugin to Package.swift:
+Add the plugin to `Package.swift`:
 ```swift
 .target(
   name: "MyApp",
@@ -121,5 +131,5 @@ Add plugin to Package.swift:
 
 ## Static Analysis Constraints
 
-1. **Type annotations may be needed** for type-based keys — analyzer infers when possible
-2. **No dynamic dispatch** — analyzer can't track through protocol-typed values or closures stored in properties. Static calls only.
+1. **Type annotations may be needed** for type-based keys — the analyzer infers when possible.
+2. **No dynamic dispatch** — the analyzer can't track through protocol-typed values or closures stored in properties. Static calls only.


### PR DESCRIPTION
## Summary

Ship a self-hosted Claude Code plugin so users of the Implicits library can install AI guidance with one command:

```
/plugin marketplace add yandex/implicits
/plugin install implicits@implicits
```

The plugin currently bundles a single skill, `implicits-usage-guide`, which auto-triggers on Swift code using `@Implicit`, `ImplicitScope`, `#withImplicits`, `#implicits`, `withScope`, or a `Package.swift` declaring a dependency on the `implicits` package.

To avoid duplicating guidance, the previous `AI_GUIDE.md` is moved into the skill at `skills/implicits-usage-guide/SKILL.md`. `AGENTS.md` now `@`-imports the skill file, so the in-repo CLAUDE.md context and the installed plugin share a single source of truth.

## Layout

```
.claude-plugin/marketplace.json     # marketplace name: implicits
.claude-plugin/plugin.json          # plugin name: implicits
skills/implicits-usage-guide/SKILL.md
docs/closures.md                    # canonical, referenced from SKILL.md
```

Future skills (e.g. `implicits-migration`) can be added under `skills/` without manifest changes — they're discovered by directory convention.

## Test plan

- [ ] `/plugin marketplace add ./` from a local clone, then `/plugin install implicits@implicits` — verify skill loads
- [ ] In a fresh Swift project depending on `implicits`, confirm the skill auto-triggers when editing files that use `@Implicit` / `ImplicitScope`
- [ ] Verify `AGENTS.md` `@`-import of `skills/implicits-usage-guide/SKILL.md` resolves correctly