### PR TITLE
Support @MainActor closures in #withImplicits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Swift library for implicit parameter passing through call stacks. Eliminate pa
 ## Table of Contents
 
 - [Installation](#installation)
+- [Claude Code Plugin](#claude-code-plugin)
 - [The Problem](#the-problem)
 - [The Solution](#the-solution)
 - [Usage Guide](#usage-guide)
@@ -41,6 +42,17 @@ Then add the library to your target:
 ```
 
 The `ImplicitsAnalysisPlugin` performs static analysis at build time to verify that all implicit parameters are properly provided through the call chain.
+
+## Claude Code Plugin
+
+If you use [Claude Code](https://claude.com/claude-code), install the bundled plugin so Claude generates correct Implicits code — scope lifetime, key selection, closure handling, and static-analysis constraints:
+
+```
+/plugin marketplace add yandex/implicits
+/plugin install implicits@implicits
+```
+
+The plugin contents live in [`.claude-plugin/`](.claude-plugin/) and [`skills/implicits-usage-guide/`](skills/implicits-usage-guide/).
 
 ## The Problem
 

--- a/Sources/Implicits/Macros.swift
+++ b/Sources/Implicits/Macros.swift
@@ -92,3 +92,71 @@ public macro withImplicits<each A, T>(
   module: "ImplicitsMacros",
   type: "WithImplicitsMacro"
 )
+
+/// Wraps a closure to capture implicit requirements from the enclosing scope.
+///
+/// Example:
+/// ```swift
+/// downloadImage(url: avatarURL, completion: #withImplicits { image, scope in
+///   @Implicit var filters: FilterApplier
+///   imageView.image = filters.applyBlur(image)
+/// })
+/// ```
+@freestanding(expression)
+public macro withImplicits<each A, T>(
+  _ body: @MainActor (repeat each A, ImplicitScope) -> T
+) -> @MainActor (repeat each A) -> T = #externalMacro(
+  module: "ImplicitsMacros",
+  type: "WithImplicitsMacro"
+)
+
+/// Wraps a closure to capture implicit requirements from the enclosing scope.
+///
+/// Example:
+/// ```swift
+/// downloadImage(url: avatarURL, completion: #withImplicits { image, scope in
+///   @Implicit var filters: FilterApplier
+///   imageView.image = filters.applyBlur(image)
+/// })
+/// ```
+@freestanding(expression)
+public macro withImplicits<each A, T>(
+  _ body: @MainActor (repeat each A, ImplicitScope) throws -> T
+) -> @MainActor (repeat each A) throws -> T = #externalMacro(
+  module: "ImplicitsMacros",
+  type: "WithImplicitsMacro"
+)
+
+/// Wraps a closure to capture implicit requirements from the enclosing scope.
+///
+/// Example:
+/// ```swift
+/// downloadImage(url: avatarURL, completion: #withImplicits { image, scope in
+///   @Implicit var filters: FilterApplier
+///   imageView.image = filters.applyBlur(image)
+/// })
+/// ```
+@freestanding(expression)
+public macro withImplicits<each A, T>(
+  _ body: @MainActor (repeat each A, ImplicitScope) async -> T
+) -> @MainActor (repeat each A) async -> T = #externalMacro(
+  module: "ImplicitsMacros",
+  type: "WithImplicitsMacro"
+)
+
+/// Wraps a closure to capture implicit requirements from the enclosing scope.
+///
+/// Example:
+/// ```swift
+/// downloadImage(url: avatarURL, completion: #withImplicits { image, scope in
+///   @Implicit var filters: FilterApplier
+///   imageView.image = filters.applyBlur(image)
+/// })
+/// ```
+@freestanding(expression)
+public macro withImplicits<each A, T>(
+  _ body: @MainActor (repeat each A, ImplicitScope) async throws -> T
+) -> @MainActor (repeat each A) async throws -> T = #externalMacro(
+  module: "ImplicitsMacros",
+  type: "WithImplicitsMacro"
+)

--- a/Tests/IntegrationTests/WithImplicitsMacroTests.swift
+++ b/Tests/IntegrationTests/WithImplicitsMacroTests.swift
@@ -37,7 +37,74 @@ struct WithImplicitsMacroTests {
     #expect(wrapped() == 12)
     #expect(wrapped() == 13)
   }
+
+  @MainActor
+  @Test func `sync @MainActor closure preserves MainActor on result`() {
+    let scope = ImplicitScope()
+    defer { scope.end() }
+
+    @Implicit(\.testID) var id = 42
+
+    let wrapped: @MainActor () -> Int = #withImplicits { @MainActor _ in
+      @Implicit(\.testID) var v: Int
+      return v + mainActorOnly()
+    }
+
+    #expect(wrapped() == 43)
+  }
+
+  @MainActor
+  @Test func `throwing @MainActor closure preserves MainActor on result`() throws {
+    let scope = ImplicitScope()
+    defer { scope.end() }
+
+    @Implicit(\.testID) var id = 7
+
+    let wrapped: @MainActor () throws -> Int = #withImplicits { @MainActor _ in
+      @Implicit(\.testID) var v: Int
+      return try v + mainActorOnlyThrowing()
+    }
+
+    #expect(try wrapped() == 8)
+  }
+
+  @MainActor
+  @Test func `async @MainActor closure preserves MainActor on result`() async {
+    let scope = ImplicitScope()
+    defer { scope.end() }
+
+    @Implicit(\.testID) var id = 11
+
+    let wrapped: @MainActor () async -> Int = #withImplicits { @MainActor _ in
+      @Implicit(\.testID) var v: Int
+      return await v + mainActorOnlyAsync()
+    }
+
+    let result = await wrapped()
+    #expect(result == 12)
+  }
+
+  @MainActor
+  @Test func `async throwing @MainActor closure preserves MainActor on result`() async throws {
+    let scope = ImplicitScope()
+    defer { scope.end() }
+
+    @Implicit(\.testID) var id = 13
+
+    let wrapped: @MainActor () async throws -> Int = #withImplicits { @MainActor _ in
+      @Implicit(\.testID) var v: Int
+      return try await v + mainActorOnlyAsyncThrowing()
+    }
+
+    let result = try await wrapped()
+    #expect(result == 14)
+  }
 }
+
+@MainActor private func mainActorOnly() -> Int { 1 }
+@MainActor private func mainActorOnlyThrowing() throws -> Int { 1 }
+@MainActor private func mainActorOnlyAsync() async -> Int { 1 }
+@MainActor private func mainActorOnlyAsyncThrowing() async throws -> Int { 1 }
 
 private func verifyInNestedScope(_ scope: ImplicitScope, wrapped: () -> Int) {
   let scope = scope.nested()

--- a/docs/closures.md
+++ b/docs/closures.md
@@ -64,15 +64,22 @@ The `scope` parameter is always last.
 
 > **Note:** Since the closure must be wrapped in the macro, you can't use trailing closure syntax for the outer function. Instead of `fetch { ... }`, you write `fetch(completion: #withImplicits { ... })`.
 
-### Async and Throws
+### Effects and Isolation
 
-The macro automatically infers `async` and `throws` from the closure body:
+The macro infers `async` and `throws` from the closure body, and preserves `@MainActor` isolation on the result (across all four effect combinations):
 
 ```swift
 #withImplicits { scope async in ... }
 #withImplicits { scope throws in ... }
 #withImplicits { scope async throws in ... }
+
+let onTap: @MainActor () -> Void = #withImplicits { @MainActor scope in
+  @Implicit var theme: Theme
+  button.backgroundColor = theme.accent
+}
 ```
+
+Custom global actors (`@MyGlobalActor`) are not supported — Swift macros cannot be parameterized over type attributes. For non-`@MainActor` isolation, use [Named Wrappers](#named-wrappers-withnameimplicits): the build-time analyzer reads the closure's attributes per call site and generates a correctly typed wrapper.
 
 ### Limitations
 


### PR DESCRIPTION
## Summary
- Adds four `@MainActor` overloads of the `#withImplicits` macro (sync, throws, async, async throws) so closures annotated with `@MainActor` compile and the wrapper result preserves `@MainActor` isolation — staying synchronously callable from a `@MainActor` context.
- Custom global actors still aren't supported (Swift macros can't be parameterized over type attributes). For those, use the existing analyzer-generated named wrappers, which already pick up isolation per call site (PR #42).
- Updates `docs/closures.md` with an "Effects and Isolation" section and adds a one-line note in `AI_GUIDE.md`.

## Test plan
- [x] `swift test` — all 119 tests pass.
- [x] New tests in `Tests/IntegrationTests/WithImplicitsMacroTests.swift` cover all four effect combinations. Each closure body calls a `@MainActor`-only function without `await`/hop, providing a compile-time proof that the closure is statically `@MainActor`. The wrapper return type is annotated `@MainActor (...) -> T`, providing a compile-time proof that isolation is preserved through the macro.