### PR TITLE
Added explicit isolation: argument to #withImplicits

### DIFF
--- a/Sources/Implicits/Macros.swift
+++ b/Sources/Implicits/Macros.swift
@@ -25,6 +25,16 @@ public macro implicits() -> Implicits = #externalMacro(
   type: "ImplicitMacro"
 )
 
+/// Selects the non-isolated overload of `#withImplicits`.
+public enum _WithImplicitsNoIsolation {
+  case none
+}
+
+/// Selects the `@MainActor`-isolated overload of `#withImplicits`.
+public enum _WithImplicitsMainActor {
+  case mainActor
+}
+
 /// Wraps a closure to capture implicit requirements from the enclosing scope.
 ///
 /// Example:
@@ -34,8 +44,11 @@ public macro implicits() -> Implicits = #externalMacro(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the non-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsNoIsolation = .none,
   _ body: (repeat each A, ImplicitScope) -> T
 ) -> (repeat each A) -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -51,8 +64,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the non-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsNoIsolation = .none,
   _ body: (repeat each A, ImplicitScope) async -> T
 ) -> (repeat each A) async -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -68,8 +84,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the non-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsNoIsolation = .none,
   _ body: (repeat each A, ImplicitScope) throws -> T
 ) -> (repeat each A) throws -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -85,8 +104,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the non-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsNoIsolation = .none,
   _ body: (repeat each A, ImplicitScope) async throws -> T
 ) -> (repeat each A) async throws -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -102,8 +124,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the `@MainActor`-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsMainActor = .mainActor,
   _ body: @MainActor (repeat each A, ImplicitScope) -> T
 ) -> @MainActor (repeat each A) -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -119,8 +144,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the `@MainActor`-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsMainActor = .mainActor,
   _ body: @MainActor (repeat each A, ImplicitScope) throws -> T
 ) -> @MainActor (repeat each A) throws -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -136,8 +164,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the `@MainActor`-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsMainActor = .mainActor,
   _ body: @MainActor (repeat each A, ImplicitScope) async -> T
 ) -> @MainActor (repeat each A) async -> T = #externalMacro(
   module: "ImplicitsMacros",
@@ -153,8 +184,11 @@ public macro withImplicits<each A, T>(
 ///   imageView.image = filters.applyBlur(image)
 /// })
 /// ```
+///
+/// - Parameter isolation: Selects the `@MainActor`-isolated overload.
 @freestanding(expression)
 public macro withImplicits<each A, T>(
+  isolation: _WithImplicitsMainActor = .mainActor,
   _ body: @MainActor (repeat each A, ImplicitScope) async throws -> T
 ) -> @MainActor (repeat each A) async throws -> T = #externalMacro(
   module: "ImplicitsMacros",

--- a/Sources/ImplicitsMacros/ImplicitsMacros.swift
+++ b/Sources/ImplicitsMacros/ImplicitsMacros.swift
@@ -32,12 +32,14 @@ public struct WithImplicitsMacro: ExpressionMacro {
     let loc = try SourceLocation(of: node, in: context)
     try loc.checkNotInMacroExpansion("withImplicits")
 
-    // Get the closure argument (either as argument or trailing closure)
+    // The closure body is the trailing closure when present, otherwise the
+    // last positional argument (an explicit isolation marker, if passed,
+    // precedes it).
     let closure: ClosureExprSyntax
     if let trailingClosure = node.trailingClosure {
       closure = trailingClosure
-    } else if let firstArg = node.arguments.first,
-              let closureExpr = firstArg.expression.as(ClosureExprSyntax.self) {
+    } else if let lastArg = node.arguments.last,
+              let closureExpr = lastArg.expression.as(ClosureExprSyntax.self) {
       closure = closureExpr
     } else {
       throw DiagnosticsError.at(node, "#withImplicits requires a closure argument")

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1083,10 +1083,16 @@ enum SemaTreeBuilder<
     // closureParamCount is all params except the scope
     let closureParamCount = params.count - 1
 
+    var typeAttributes = closure.typeAttributes
+    if macro.requestsMainActorIsolation,
+       !typeAttributes.contains(where: \.isMainActor) {
+      typeAttributes.append(.identifier("MainActor"))
+    }
+
     let effects = ClosureEffects(
       isAsync: closure.isAsync,
       isThrowing: closure.isThrowing,
-      typeAttributes: closure.typeAttributes
+      typeAttributes: typeAttributes
     )
     let body = visit(
       codeBlockEntities: closure.body,
@@ -1564,10 +1570,31 @@ extension SyntaxTree.MacroExpansion {
     if let trailing = trailingClosure {
       return trailing
     }
-    if let arg = arguments.singleElement, case let .closure(expr) = arg.value {
-      return .init(value: expr, syntax: arg.syntax)
+    // The closure is at most one positional arg (other args carry markers
+    // like `isolation:`); take the last one if it is a closure.
+    if let last = arguments.last, case let .closure(expr) = last.value.value {
+      return .init(value: expr, syntax: last.value.syntax)
     }
     return nil
+  }
+
+  /// Whether the macro call has an explicit `isolation: .mainActor` argument.
+  /// Interpreted semantically from the labeled-arg shape rather than baked
+  /// into the syntax tree.
+  var requestsMainActorIsolation: Bool {
+    arguments.contains { arg in
+      guard arg.name?.value == "isolation",
+            case let .memberAccessor(_, name) = arg.value.value
+      else { return false }
+      return name == "mainActor"
+    }
+  }
+}
+
+extension SyntaxTree.TypeModel {
+  fileprivate var isMainActor: Bool {
+    if case let .identifier(name) = self { return name == "MainActor" }
+    return false
   }
 }
 

--- a/Sources/ImplicitsTool/SyntaxTree.swift
+++ b/Sources/ImplicitsTool/SyntaxTree.swift
@@ -167,9 +167,14 @@ public enum SyntaxTree<Syntax> {
 
   public struct MacroExpansion {
     public var name: String
-    public var arguments: [Entity<Expression>]
+    public var arguments: [LabeledArgument]
     public var trailingClosure: Entity<ClosureExpr>?
     public var additionalTrailingClosures: [LabeledTrailingClosure]
+
+    public struct LabeledArgument {
+      public var name: Entity<String>?
+      public var value: Entity<Expression>
+    }
   }
 
   /// Represents initializer declaration
@@ -792,7 +797,12 @@ extension SyntaxTree.MacroExpansion {
   func mapSyntax<S>(_ t: (Syntax) -> S) -> SyntaxTree<S>.MacroExpansion {
     .init(
       name: name,
-      arguments: arguments.map { $0.map(t, ST.Expression.mapSyntax) },
+      arguments: arguments.map {
+        .init(
+          name: $0.name?.mapSyntax(t),
+          value: $0.value.map(t, ST.Expression.mapSyntax)
+        )
+      },
       trailingClosure: trailingClosure?.map(t, ST.ClosureExpr.mapSyntax),
       additionalTrailingClosures: additionalTrailingClosures.map { $0.mapSyntax(t) }
     )

--- a/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeBuilder.swift
@@ -496,8 +496,11 @@ extension MacroExpansionExprSyntax: SyntaxDescriptionProvider {
       name: macroName.text,
       arguments: arguments.map { arg in
         .init(
-          value: arg.expression.syntaxDescription(context: context),
-          syntax: Syntax(arg.expression)
+          name: arg.label.map { SXT.Entity(value: $0.text, syntax: Syntax($0)) },
+          value: .init(
+            value: arg.expression.syntaxDescription(context: context),
+            syntax: Syntax(arg.expression)
+          )
         )
       },
       trailingClosure: trailingClosure.map {

--- a/Sources/TestResources/test_data/support_file.swift
+++ b/Sources/TestResources/test_data/support_file.swift
@@ -173,6 +173,14 @@ private func requires(_: ImplicitScope) {
   var a2: UInt16
 }
 
+// Explicit isolation argument: analyzer must respect `isolation: .mainActor`
+// even when the closure body lacks an `@MainActor` annotation.
+private func withExplicitIsolation(_: ImplicitScope) {
+  _ = #withImplicits(isolation: .mainActor) { scope in
+    requires(scope)
+  }
+}
+
 // Helper stubs for effect testing
 private func asyncFunc() async {}
 private func throwingFunc() throws {}

--- a/Sources/TestResources/test_data/support_file_snapshot.swift
+++ b/Sources/TestResources/test_data/support_file_snapshot.swift
@@ -142,6 +142,17 @@ internal func __implicit_wrap_support_file_swift_86_7<T>(_ body: @escaping (Impl
   }
 }
 
+internal func __implicit_wrap_support_file_swift_179_7<T>(_ body: @escaping @MainActor (ImplicitScope) -> T) -> @MainActor () -> T {
+  let implicits = Implicits(unsafeKeys: Implicits.getRawKey((UInt16).self), Implicits.getRawKey((UInt8).self))
+  return {
+    let scope = ImplicitScope(with: implicits)
+    defer {
+      scope.end()
+    }
+    return body(scope)
+  }
+}
+
 public func supportFileFunc(arg: Int, bool: @autoclosure () -> Bool, keyFromAnotherModule: @autoclosure () -> [String: [Int]], supportFileKey2: @autoclosure () -> [Int]) {
   let scope = ImplicitScope()
   defer {

--- a/Sources/TestResources/test_data/with_implicits_macro.swift
+++ b/Sources/TestResources/test_data/with_implicits_macro.swift
@@ -76,3 +76,37 @@ private func __implicit_wrap_with_implicits_macro_swift_31_7<T>(_ body: @escapin
 private func __implicit_wrap_with_implicits_macro_swift_41_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_51_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
 private func __implicit_wrap_with_implicits_macro_swift_65_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+
+private func explicitNoIsolation() {
+  // expected-error@+1 {{Unresolved requirement: Int64}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  _ = #withImplicits(isolation: .none) { scope in
+    @Implicit() var v1: Int64
+  }
+}
+
+private func explicitNoIsolationParenthesized() {
+  // expected-error@+1 {{Unresolved requirement: UInt64}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  _ = #withImplicits(isolation: .none, { scope in
+    @Implicit() var v1: UInt64
+  })
+}
+
+private func explicitMainActor() {
+  // expected-error@+1 {{Unresolved requirement: UInt16}}
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  _ = #withImplicits(isolation: .mainActor) { @MainActor scope in
+    @Implicit() var v1: UInt16
+  }
+}
+
+private func __implicit_wrap_with_implicits_macro_swift_85_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+private func __implicit_wrap_with_implicits_macro_swift_95_7<T>(_ body: @escaping (ImplicitScope) -> T) -> () -> T { fatalError() }
+private func __implicit_wrap_with_implicits_macro_swift_105_7<T>(_ body: @escaping @MainActor (ImplicitScope) -> T) -> @MainActor () -> T { fatalError() }

--- a/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
+++ b/Tests/ImplicitsToolTests/ImplicitsMacrosTests.swift
@@ -1,14 +1,40 @@
 // Copyright 2023 Yandex LLC. All rights reserved.
 
 import ImplicitsMacros
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
-private let testMacros: [String: Macro.Type] = [
-  "implicits": ImplicitMacro.self,
-  "withImplicits": WithImplicitsMacro.self,
+private let testMacros: [String: MacroSpec] = [
+  "implicits": MacroSpec(type: ImplicitMacro.self),
+  "withImplicits": MacroSpec(type: WithImplicitsMacro.self),
 ]
+
+/// Bridges swift-syntax's macro-expansion assertions to Swift Testing.
+/// The default `assertMacroExpansion` from `SwiftSyntaxMacrosTestSupport`
+/// reports failures via `XCTFail`, which Swift Testing does not observe.
+private func assertMacroExpansion(
+  _ originalSource: String,
+  expandedSource expectedExpandedSource: String,
+  diagnostics: [DiagnosticSpec] = [],
+  macros: [String: MacroSpec],
+  sourceLocation: Testing.SourceLocation = #_sourceLocation
+) {
+  SwiftSyntaxMacrosGenericTestSupport.assertMacroExpansion(
+    originalSource,
+    expandedSource: expectedExpandedSource,
+    diagnostics: diagnostics,
+    macroSpecs: macros,
+    failureHandler: { failure in
+      Issue.record(
+        Comment(rawValue: failure.message),
+        sourceLocation: sourceLocation
+      )
+    }
+  )
+}
 
 struct ImplicitMacroTests {
   @Test func `implicit macro`() {
@@ -30,7 +56,9 @@ struct ImplicitMacroTests {
       let c = #withImplicits { _ in 42 }
       """,
       expandedSource: """
-      let c = __implicit_wrap_test_swift_1_9({ _ in 42 })
+      let c = __implicit_wrap_test_swift_1_9({ _ in
+              42
+          })
       """,
       diagnostics: [],
       macros: testMacros
@@ -43,7 +71,9 @@ struct ImplicitMacroTests {
       let c = #withImplicits({ _ in 42 })
       """,
       expandedSource: """
-      let c = __implicit_wrap_test_swift_1_9({ _ in 42 })
+      let c = __implicit_wrap_test_swift_1_9({ _ in
+              42
+          })
       """,
       diagnostics: [],
       macros: testMacros
@@ -71,7 +101,39 @@ struct ImplicitMacroTests {
       let c = #withImplicits({ [weak self] scope in 42 })
       """,
       expandedSource: """
-      let c = __implicit_wrap_test_swift_1_9({ [weak self] scope in 42 })
+      let c = __implicit_wrap_test_swift_1_9({ [weak self] scope in
+              42
+          })
+      """,
+      diagnostics: [],
+      macros: testMacros
+    )
+  }
+
+  @Test func `with implicits macro explicit isolation: .none`() {
+    assertMacroExpansion(
+      """
+      let c = #withImplicits(isolation: .none) { _ in 42 }
+      """,
+      expandedSource: """
+      let c = __implicit_wrap_test_swift_1_9({ _ in
+              42
+          })
+      """,
+      diagnostics: [],
+      macros: testMacros
+    )
+  }
+
+  @Test func `with implicits macro explicit isolation: .mainActor`() {
+    assertMacroExpansion(
+      """
+      let c = #withImplicits(isolation: .mainActor) { @MainActor _ in 42 }
+      """,
+      expandedSource: """
+      let c = __implicit_wrap_test_swift_1_9({ @MainActor _ in
+              42
+          })
       """,
       diagnostics: [],
       macros: testMacros


### PR DESCRIPTION
## Summary
- New `isolation: .none` / `isolation: .mainActor` argument on `#withImplicits` lets callers pick the overload explicitly instead of relying solely on closure-body inference (`@MainActor` annotation or call-site contextual type).
- The static analyzer respects the explicit arg: `isolation: .mainActor` produces an `@MainActor`-bound wrapper even when the closure body has no `@MainActor` attribute.
- Discovered that the previous `assertMacroExpansion` calls in `ImplicitsToolTests` were silently no-ops under Swift Testing — `SwiftSyntaxMacrosTestSupport` reports via `XCTFail`, which Swift Testing does not pick up. Added a bridge that funnels failures to `Issue.record`, and updated the existing expected expansions to match the actual formatter output that the now-working assertion produces.

## Behaviour
```swift
// non-isolated overload (default) — unchanged
let a = #withImplicits { _, scope in ... }

// explicitly non-isolated, e.g. to side-step Swift-5 strict-concurrency macro
// expansion edge cases where @MainActor overloads would be picked
let b = #withImplicits(isolation: .none) { _, scope in ... }

// @MainActor overload, with or without body annotation
let c: @MainActor () -> Int = #withImplicits(isolation: .mainActor) { @MainActor _, scope in ... }
```

The macro overload set grows from 9 (one per effect+isolation combination) to the same 9 plus the new isolation parameter. The new arg has a default value, so existing call sites compile unchanged.

## Test plan
- [x] `swift test` — 121/121 pass.
- [x] Macro-expansion tests in `ImplicitsToolTests` now actually run (failures surface via `Issue.record`); added cases for both isolation variants.
- [x] Static analyzer tests in `with_implicits_macro.swift` cover trailing-closure, parenthesized, and `@MainActor` body forms.
- [x] Snapshot test in `support_file.swift` covers `isolation: .mainActor` without `@MainActor` body annotation — verifies the analyzer emits a `@MainActor` wrapper from the explicit arg alone.