### PR TITLE
Fix stored implicit bag dropping requirements when type has @Implicit properties

### DIFF
--- a/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
+++ b/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
@@ -228,7 +228,7 @@ extension UnresolvedGraph {
       storedBags[namespace] = bagNode
       bags.append((bag, bagNode, file))
       if var initializer = implicitStoredProperties[namespace] {
-        graph.addEdge(from: bagNode, to: initializer.tail)
+        graph.addEdge(from: initializer.tail, to: bagNode)
         initializer.tail = bagNode
         implicitStoredProperties[namespace] = initializer
       } else {

--- a/Sources/TestResources/test_data/stored_implicit_bag.swift
+++ b/Sources/TestResources/test_data/stored_implicit_bag.swift
@@ -2,12 +2,13 @@
 import Implicits
 
 private func entry() {
-  // expected-error@+1 {{Unresolved requirements: UInt16, UInt32, UInt8}}
+  // expected-error@+1 {{Unresolved requirements: Int8, UInt16, UInt32, UInt64, UInt8}}
   let scope = ImplicitScope()
   defer { scope.end() }
 
   _ = StoresImplicitsBag(scope)
   _ = ImplicitBagMacro(scope)
+  _ = BagWithImplicitProperty(scope)
 }
 
 private struct StoresImplicitsBag {
@@ -96,7 +97,7 @@ private struct ImplicitBagMacro {
   }
 }
 
-private func __implicit_bag_stored_implicit_bag_swift_86_19() -> Implicits {
+private func __implicit_bag_stored_implicit_bag_swift_87_19() -> Implicits {
   return Implicits()
 }
 
@@ -109,5 +110,26 @@ private func testBag2Implicits() -> Implicits {
 }
 
 private func testBag3Implicits() -> Implicits {
+  return Implicits()
+}
+
+private struct BagWithImplicitProperty {
+  @Implicit()
+  var dep: Int8
+
+  let implicits = testBag4Implicits()
+
+  init(_: ImplicitScope) {}
+
+  func usesBag() {
+    let scope = ImplicitScope(with: implicits)
+    defer { scope.end() }
+
+    @Implicit()
+    var v1: UInt64
+  }
+}
+
+private func testBag4Implicits() -> Implicits {
   return Implicits()
 }


### PR DESCRIPTION
## Problem

When a type declares **both** `@Implicit` stored properties **and** a stored
`#implicits` bag, the bag's requirements were silently not enforced at the
type's construction sites. The static analysis tool accepted code it should
have rejected, and the dropped keys surfaced at runtime as
`No value for <Key>` fatal errors inside `withScope(with:)`.

## Root cause

In `RequirementsGraphBuilder.traverse(memberItem:...)`, the stored-bag node was
linked into the requirements graph with a reversed edge:

```swift
graph.addEdge(from: bagNode, to: initializer.tail)   // wrong direction
```

Requirements propagate from a node's successors into the node. The stored
`@Implicit` properties form the chain `init → P1 → … → Pn`, so their
requirements correctly reach every initializer. The reversed bag edge
(`bagNode → Pn`) instead made the bag node **unreachable from the
initializer**, so the bag's requirements never reached the construction sites
and went unchecked.

When the type had a bag but **no** `@Implicit` properties, the bag became the
chain head and everything worked — which is why the existing fixture never
caught it.

## Fix

Link the bag as a successor of the property chain's tail, matching the
direction used for the `@Implicit` property chain itself:

```swift
graph.addEdge(from: initializer.tail, to: bagNode)
```

## Test

Extended `stored_implicit_bag.swift` with a type that has both an `@Implicit`
property and a stored bag whose user requires a distinct key.

- Without the fix: the entry-point diagnostic omits the bag's requirement
  (`Unresolved requirements: Int8, UInt16, UInt32, UInt8` — `UInt64` dropped).
- With the fix: `Unresolved requirements: Int8, UInt16, UInt32, UInt64, UInt8`.

Full `ImplicitsToolTests` suite passes (85 tests), including the support-file
snapshot.