### PR TITLE
Detect duplicate implicit key declaration in the same scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,12 +68,24 @@ swift run implicits-tool-spm-plugin <args-file>
    }
    ```
 
+## Analyzer Architecture
+
+The static analyzer (`ImplicitsTool`) is a three-stage pipeline: `SyntaxTreeBuilder` → `SemaTreeBuilder` → `RequirementsGraphBuilder`. Scope dataflow — the local/inherited/none state machine, writability, nesting, scope-end and other cross-statement scope rules — lives only in the last stage (`CodeBlockState`); add scope rules there, not in the earlier stages.
+
 ## Testing
 
 **Necessity and sufficiency principle**: Every test must add unique use case coverage. Don't write tests for the sake of tests - each test should verify a specific behavior that isn't already covered.
 
-- Integration tests are in `Sources/TestResources/test_data/` - check these for examples when implementing new features
-- Tests use inline annotations (e.g., `// expected-error`, `// expect-syntax:`) to specify expected behavior
+Analyzer regression tests are the `test_data/*.swift` files in `Sources/TestResources/test_data/` (run from `StaticAnalysisTests.swift`): ordinary Swift exercising the analyzer, with expected diagnostics asserted by inline comments. They look like:
+
+```swift
+private func entry() {
+  // expected-error@+1 {{Using implicits without 'ImplicitScope'}}
+  @Implicit() var v: Int
+}
+```
+
+`@+1` points the comment at the next line; omit it to annotate the same line. Also `expected-note`/`expected-warning` and `expected-key …` for key declarations. The harness matches diagnostics as a set — an unexpected one fails just like a missing one.
 
 ## File Organization
 

--- a/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
+++ b/Sources/ImplicitsTool/RequirementsGraphBuilder.swift
@@ -314,9 +314,15 @@ extension UnresolvedGraph {
   // MARK: CodeBlock
 
   struct CodeBlockState {
+    struct LocalScope {
+      var declaredAt: Syntax
+      var endedAt: Syntax?
+      var providedKeys: [ImplicitKey: Syntax] = [:]
+    }
+
     enum Scope {
       case inherited
-      case local(declaredAt: Syntax, endedAt: Syntax?)
+      case local(LocalScope)
     }
 
     var parent: Idx?
@@ -403,13 +409,13 @@ extension UnresolvedGraph {
         diagnostics.check(
           nested, or: .newScopeWhileInheriting, at: at, severity: .warning
         )
-        scope = .local(declaredAt: at, endedAt: nil)
+        scope = .local(LocalScope(declaredAt: at))
       case .none:
         diagnostics.check(!nested, or: .nestingNoScope, at: at)
-        scope = .local(declaredAt: at, endedAt: nil)
-      case let .local(declared, _):
+        scope = .local(LocalScope(declaredAt: at))
+      case let .local(local):
         diagnostics.diagnose(.moreThanOneLocalScope, at: at)
-        diagnostics.note(.scopeDeclaredHere, at: declared)
+        diagnostics.note(.scopeDeclaredHere, at: local.declaredAt)
       }
     }
 
@@ -417,12 +423,13 @@ extension UnresolvedGraph {
       switch scope {
       case .inherited, .none:
         diagnostics.diagnose(.endingNonLocalScope, at: at)
-      case let .local(declared, ended):
-        if let alreadyEnded = ended {
+      case var .local(local):
+        if let alreadyEnded = local.endedAt {
           diagnostics.diagnose(.endingScopeMultipleTimes, at: at)
           diagnostics.diagnose(.scopeEndedHere, at: alreadyEnded, severity: .note)
         }
-        scope = .local(declaredAt: declared, endedAt: at)
+        local.endedAt = at
+        scope = .local(local)
       }
     }
 
@@ -430,27 +437,34 @@ extension UnresolvedGraph {
       switch scope {
       case .inherited, .none:
         break
-      case let .local(declared, ended):
+      case let .local(local):
         diagnostics.check(
-          ended != nil,
+          local.endedAt != nil,
           or: .scopeIsNotEnded,
-          at: declared
+          at: local.declaredAt
         )
       }
     }
 
-    func checkOnWriteAccess(into diagnostics: inout Diagnostics, at syntax: Syntax) {
+    mutating func implicitSet(
+      _ key: ImplicitKey,
+      into diagnostics: inout Diagnostics,
+      at syntax: Syntax
+    ) {
       switch scope {
       case .inherited, .none:
         diagnostics.diagnose(.noWritableScope, at: syntax)
-      case .local:
-        break
+      case var .local(local):
+        if let previous = local.providedKeys[key] {
+          diagnostics.diagnose(.duplicateImplicit(key), at: syntax)
+          diagnostics.note(.previousImplicitDeclaration, at: previous)
+        } else {
+          local.providedKeys[key] = syntax
+          scope = .local(local)
+        }
       }
       if let ifConfigCondition {
-        diagnostics.diagnose(
-          .noMutationInIfConfig,
-          at: syntax
-        )
+        diagnostics.diagnose(.noMutationInIfConfig, at: syntax)
         diagnostics.note(.unresolvedIfConfigCondition, at: ifConfigCondition)
       }
     }
@@ -606,7 +620,7 @@ extension UnresolvedGraph {
           provides: [implicit.key],
           parent: state.parent
         )
-        state.checkOnWriteAccess(into: &diagnostics, at: sema.syntax)
+        state.implicitSet(implicit.key, into: &diagnostics, at: sema.syntax)
       }
     case let .implicitMap(from: from, to: to):
       state.parent = addNode(
@@ -615,7 +629,7 @@ extension UnresolvedGraph {
         requires: [from],
         parent: state.parent
       )
-      state.checkOnWriteAccess(into: &diagnostics, at: sema.syntax)
+      state.implicitSet(to, into: &diagnostics, at: sema.syntax)
     case let .withScope(nested: isNested, withBag: usesBag, body: body):
       var innerState = state.innerScopeLense
       defer { state.innerScopeLense = innerState }
@@ -756,6 +770,12 @@ extension DiagnosticMessage {
     "Implicitly overriding existing scope"
   fileprivate static let moreThanOneLocalScope: Self =
     "Multiple local implicit scopes"
+  fileprivate static func duplicateImplicit(_ key: ImplicitKey) -> Self {
+    "Redeclaring implicit '\(key.descriptionForDiagnostics)' in the same scope"
+  }
+
+  fileprivate static let previousImplicitDeclaration: Self =
+    "Previous declaration here"
   fileprivate static let scopeDeclaredHere: Self =
     "Foremost declaration"
   fileprivate static let endingNonLocalScope: Self =

--- a/Sources/TestResources/test_data/implicit_map.swift
+++ b/Sources/TestResources/test_data/implicit_map.swift
@@ -21,6 +21,10 @@ private func entry() {
     let scope = scope.nested()
     defer { scope.end() }
 
+    // expected-note@+1 {{Previous declaration here}}
+    Implicit.map(UInt16.self, to: Int16.self) { _ in 0 }
+
+    // expected-error@+1 {{Redeclaring implicit 'Int16' in the same scope}}
     Implicit.map(UInt16.self, to: Int16.self) { _ in 0 }
 
     @Implicit()

--- a/Sources/TestResources/test_data/implicit_scope_order.swift
+++ b/Sources/TestResources/test_data/implicit_scope_order.swift
@@ -106,6 +106,19 @@ private func entry1() {
   }
 }
 
+private func duplicateKeyInScope() {
+  let scope = ImplicitScope()
+  defer { scope.end() }
+
+  // expected-note@+2 {{Previous declaration here}}
+  @Implicit()
+  var first: UInt8 = 0
+
+  // expected-error@+2 {{Redeclaring implicit 'UInt8' in the same scope}}
+  @Implicit()
+  var second: UInt8 = 0
+}
+
 private func code() {}
 private func code(_: ImplicitScope) {}
 


### PR DESCRIPTION
## What

The static analyzer now errors when the same implicit key is declared twice in one scope, with a note pointing at the first declaration:

```swift
let scope = ImplicitScope()
defer { scope.end() }

@Implicit(\.id) var id = 1
@Implicit(\.id) var dup = 2 // error: Redeclaring implicit '\.id' in the same scope
```

## Why

Redeclaring the same key in one scope is a footgun — overriding a value is meant to happen in a nested scope. It used to be silently allowed.

The check is routed through a shared `implicitSet` on `CodeBlockState`, which also closes a gap: `Implicit.map`'s target key was never tracked, so a `map(to:)` colliding with another declaration in the same scope went unnoticed.

## Tests

- `implicit_scope_order.swift` — duplicate `@Implicit` set in one scope.
- `implicit_map.swift` — duplicate via `Implicit.map`'s target (the gap above).
- Existing nested-scope tests (`graph_basic`, `with_scope`) already cover the legal override-in-nested-scope path, so no regression there.

Also documents the analyzer's three-stage pipeline and the regression-test format in `AGENTS.md`.