### PR TITLE
Propagate import attributes into the generated support file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,8 @@ swift run implicits-tool-spm-plugin <args-file>
 
 The static analyzer (`ImplicitsTool`) is a three-stage pipeline: `SyntaxTreeBuilder` → `SemaTreeBuilder` → `RequirementsGraphBuilder`. Scope dataflow — the local/inherited/none state machine, writability, nesting, scope-end and other cross-statement scope rules — lives only in the last stage (`CodeBlockState`); add scope rules there, not in the earlier stages.
 
+Source-level name literals (keywords, identifiers, attribute names) live in `ImplicitKeyword` (`Constants.swift`) — reference them, don't hardcode strings like `"testable"`. Semantic predicates over an attribute (`isImplicit`, `isTestable`, `importAttribute`, …) all live in `SyntaxTreeAttribute.swift`; add new ones there, not inline in a builder. Structural extensions on `SyntaxTree.Attribute` (`mapSyntax`, `render`) stay beside their siblings instead.
+
 ## Testing
 
 **Necessity and sufficiency principle**: Every test must add unique use case coverage. Don't write tests for the sake of tests - each test should verify a specific behavior that isn't already covered.
@@ -87,11 +89,13 @@ private func entry() {
 
 `@+1` points the comment at the next line; omit it to annotate the same line. Also `expected-note`/`expected-warning` and `expected-key …` for key declarations. The harness matches diagnostics as a set — an unexpected one fails just like a missing one.
 
+Every file under `test_data/` is also a build input: the `__TestResourcesCompilation` target compiles the whole directory against `Implicits` + `AnotherModule`, so each test-data and snapshot file must be valid Swift importing only real modules (`Implicits`, `AnotherModule`, or system frameworks) — you can't `import` a made-up module to exercise import handling. Some tests also assert the generated support file against a checked-in `*_snapshot.swift`; when rendering changes, update that snapshot and keep it compilable too.
+
 ## File Organization
 
 - **Main type first**: The primary type of a file goes at the top. If a file is named `Foo.swift`, the `Foo` type should be at the top.
 - **Helper/utility types at the bottom**: Supporting structs, enums, extensions, and helper types go after the main type, not before it.
-- **Extensions of the main type**: Place extensions of the file's main type immediately after the main type definition.
+- **Extensions of the main type**: Prefer the type's own body for its members and nested types; use a same-file extension only to group a distinct concern, and place it immediately after the main type definition. Keep companion nested types together rather than leaving one free-floating.
 - **Extensions of other types**: Place extensions of unrelated types (like `DiagnosticMessage`) at the bottom.
 
 ## Important Constraints

--- a/Sources/ImplicitsTool/Constants.swift
+++ b/Sources/ImplicitsTool/Constants.swift
@@ -25,8 +25,14 @@ enum ImplicitKeyword {
   }
 
   enum SPI {
-    static let attributeName = "_spi"
     static let annotationName = "Implicits"
+  }
+
+  /// Built-in Swift attributes the analyzer recognizes but Implicits doesn't declare.
+  enum SwiftAttribute {
+    static let testable = "testable"
+    static let exported = "_exported"
+    static let spi = "_spi"
   }
 
   static let importModuleName = "Implicits"

--- a/Sources/ImplicitsTool/SemaTreeBuilder.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilder.swift
@@ -1373,30 +1373,6 @@ extension SyntaxTree.Parameter {
   }
 }
 
-extension SyntaxTree.Attribute {
-  var simpleIdentifier: String? {
-    switch self.name {
-    case let .identifier(id): id
-    default: nil
-    }
-  }
-
-  var isImplicit: Bool {
-    simpleIdentifier == ImplicitKeyword.Annotation.implicit
-  }
-
-  var isImplicitSpi: Bool {
-    guard
-      simpleIdentifier == ImplicitKeyword.SPI.attributeName,
-      let args = arguments,
-      let arg = args.first, args.count == 1
-    else {
-      return false
-    }
-    return arg.value.value.simpleIdentifier() == ImplicitKeyword.SPI.annotationName
-  }
-}
-
 extension Sema.FuncModifier {
   init?(_ m: SyntaxTreeBuildingBlocks.DeclModifier) {
     switch m {
@@ -1761,7 +1737,7 @@ extension DiagnosticMessage {
   // MARK: SPI
 
   fileprivate static let publicWithoutSPI: Self =
-    "Public function must be marked with '@\(ImplicitKeyword.SPI.attributeName)(\(ImplicitKeyword.SPI.annotationName))' attribute when exporting enabled"
+    "Public function must be marked with '@\(ImplicitKeyword.SwiftAttribute.spi)(\(ImplicitKeyword.SPI.annotationName))' attribute when exporting enabled"
 
   // MARK: Unknown syntax
 

--- a/Sources/ImplicitsTool/SemaTreeBuilderScout.swift
+++ b/Sources/ImplicitsTool/SemaTreeBuilderScout.swift
@@ -392,9 +392,3 @@ extension SyntaxTree.TypeModel {
     }
   }
 }
-
-extension SyntaxTree.Attribute {
-  var isTestable: Bool {
-    self.simpleIdentifier == "testable" && self.arguments == nil
-  }
-}

--- a/Sources/ImplicitsTool/StaticAnalysis.swift
+++ b/Sources/ImplicitsTool/StaticAnalysis.swift
@@ -220,9 +220,3 @@ extension SyntaxTree.TopLevelStatement {
     return value
   }
 }
-
-extension SyntaxTree.Attribute {
-  var isExported: Bool {
-    self.simpleIdentifier == "_exported" && self.arguments == nil
-  }
-}

--- a/Sources/ImplicitsTool/SupportFile.swift
+++ b/Sources/ImplicitsTool/SupportFile.swift
@@ -24,9 +24,29 @@ public struct SupportFile {
     public var requirements: [ImplicitKey]
   }
 
+  struct Import {
+    var visibility: Visibility
+    var module: String
+    var attributes: Set<ImportAttribute>
+    var debugBlame: String
+  }
+
+  enum ImportAttribute: Hashable, Comparable {
+    case testable
+    case spi(String)
+    case exported
+
+    var isPropagated: Bool {
+      switch self {
+      case .testable, .spi: true
+      case .exported: false
+      }
+    }
+  }
+
   var keys: [Sema.ImplicitKeyDecl]
-  var imports: [(Visibility, String, debugBlame: String)]
-  var ifFalseImports: [(Visibility, String, debugBlame: String)]
+  var imports: [Import]
+  var ifFalseImports: [Import]
   var functions: [(FuncSignature, [ImplicitParameter])]
   var ifFalseFunctions: [(FuncSignature, [ImplicitParameter])]
   var bags: [(name: String, requirements: [ImplicitKey])]

--- a/Sources/ImplicitsTool/SupportFileBuilder.swift
+++ b/Sources/ImplicitsTool/SupportFileBuilder.swift
@@ -160,27 +160,30 @@ enum SupportFileBuilder<Syntax> {
 }
 
 private struct ImportsIndex {
-  var store: [String: [(Visibility, debugBlame: String)]] = [:]
-
-  private mutating func register(
-    key: String, visibility: Visibility, blame: String
-  ) {
-    store[key, default: []].append((visibility, blame))
+  private struct Entry {
+    var visibility: Visibility
+    var attributes: Set<SupportFile.ImportAttribute>
+    var debugBlame: String
   }
+
+  private var store: [String: [Entry]] = [:]
 
   mutating func registerImport(
     module: String, visibility: Visibility, blame: String
   ) {
-    register(key: module, visibility: visibility, blame: blame)
+    store[module, default: []].append(
+      Entry(visibility: visibility, attributes: [], debugBlame: blame)
+    )
   }
 
   mutating func registerImport(
     _ decl: SyntaxTree<some Any>.ImportDecl, blame: String
   ) {
-    register(
-      key: decl.importedSymbolDescr,
-      visibility: decl.visibility, blame: blame
-    )
+    store[decl.importedSymbolDescr, default: []].append(Entry(
+      visibility: decl.visibility,
+      attributes: Set(decl.attributes.compactMap(\.importAttribute).filter(\.isPropagated)),
+      debugBlame: blame
+    ))
   }
 
   mutating func registerImports(
@@ -191,16 +194,17 @@ private struct ImportsIndex {
     }
   }
 
-  func sortedImports() -> [(Visibility, String, debugBlame: String)] {
-    store.map {
-      (
-        $0.value.max {
-          $0.0.visibilityRelation < $1.0.visibilityRelation
-        }?.0 ?? .default,
-        $0.key,
-        debugBlame: $0.value.map(\.debugBlame).joined(separator: ", ")
+  func sortedImports() -> [SupportFile.Import] {
+    store.map { module, entries in
+      SupportFile.Import(
+        visibility: entries.max {
+          $0.visibility.visibilityRelation < $1.visibility.visibilityRelation
+        }?.visibility ?? .default,
+        module: module,
+        attributes: entries.reduce(into: []) { $0.formUnion($1.attributes) },
+        debugBlame: entries.map(\.debugBlame).joined(separator: ", ")
       )
-    }.sorted { $0.1 < $1.1 }
+    }.sorted { $0.module < $1.module }
   }
 }
 

--- a/Sources/ImplicitsTool/SupportFileRendering.swift
+++ b/Sources/ImplicitsTool/SupportFileRendering.swift
@@ -246,29 +246,42 @@ private func implicitsCallSyntax(requirements: [ImplicitKey]) -> FunctionCallExp
 }
 
 private func importSyntax(
-  imports: [(Visibility, String, debugBlame: String)],
+  imports: [SupportFile.Import],
   needsImplicitsUnsafeSPI: Bool,
   accessLevelOnImports: Bool,
   renderBlame: Bool
 ) -> [ImportDeclSyntax] {
-  imports.map { visibility, moduleName, debugBlame in
+  imports.map { imp in
     let attributes = AttributeListSyntax {
-      if needsImplicitsUnsafeSPI, moduleName == ImplicitKeyword.importModuleName {
+      if needsImplicitsUnsafeSPI, imp.module == ImplicitKeyword.importModuleName {
         "@_spi(Unsafe)"
+      }
+      for attribute in imp.attributes.sorted() {
+        attribute.syntax
       }
     }
     return ImportDeclSyntax(
       attributes: attributes,
       modifiers: .init(itemsBuilder: {
-        if accessLevelOnImports, let visibility = visibility.render() {
+        if accessLevelOnImports, let visibility = imp.visibility.render() {
           visibility
         }
       }),
       path: ImportPathComponentListSyntax {
-        ImportPathComponentSyntax(name: .identifier(moduleName))
+        ImportPathComponentSyntax(name: .identifier(imp.module))
       },
-      trailingTrivia: renderBlame ? .blockComment(" /* \(debugBlame) */") : nil
+      trailingTrivia: renderBlame ? .blockComment(" /* \(imp.debugBlame) */") : nil
     )
+  }
+}
+
+extension SupportFile.ImportAttribute {
+  fileprivate var syntax: AttributeListSyntax.Element {
+    switch self {
+    case .testable: .attribute("@testable")
+    case let .spi(group): .attribute("@_spi(\(raw: group))")
+    case .exported: .attribute("@_exported")
+    }
   }
 }
 

--- a/Sources/ImplicitsTool/SyntaxTreeAttribute.swift
+++ b/Sources/ImplicitsTool/SyntaxTreeAttribute.swift
@@ -1,0 +1,43 @@
+// Copyright 2023 Yandex LLC. All rights reserved.
+
+extension SyntaxTree.Attribute {
+  var simpleIdentifier: String? {
+    switch self.name {
+    case let .identifier(id): id
+    default: nil
+    }
+  }
+
+  var isImplicit: Bool {
+    simpleIdentifier == ImplicitKeyword.Annotation.implicit
+  }
+
+  var isImplicitSpi: Bool {
+    guard
+      simpleIdentifier == ImplicitKeyword.SwiftAttribute.spi,
+      let args = arguments,
+      let arg = args.first, args.count == 1
+    else {
+      return false
+    }
+    return arg.value.value.simpleIdentifier() == ImplicitKeyword.SPI.annotationName
+  }
+
+  var isTestable: Bool {
+    self.simpleIdentifier == ImplicitKeyword.SwiftAttribute.testable && self.arguments == nil
+  }
+
+  var isExported: Bool {
+    self.simpleIdentifier == ImplicitKeyword.SwiftAttribute.exported && self.arguments == nil
+  }
+
+  var importAttribute: SupportFile.ImportAttribute? {
+    switch (name, arguments) {
+    case (.identifier(ImplicitKeyword.SwiftAttribute.testable), nil): .testable
+    case (.identifier(ImplicitKeyword.SwiftAttribute.exported), nil): .exported
+    case let (.identifier(ImplicitKeyword.SwiftAttribute.spi), args?) where args.count == 1:
+      args.first?.value.value.simpleIdentifier().map(SupportFile.ImportAttribute.spi)
+    default: nil
+    }
+  }
+}

--- a/Sources/TestResources/test_data/support_file.swift
+++ b/Sources/TestResources/test_data/support_file.swift
@@ -1,9 +1,9 @@
 /// See `n_support_file_snapshot.swift` , that includes all generated code for support file
 /// based on API usage in this file.
 
-import Foundation
+@_exported import Foundation
 
-import AnotherModule
+@_spi(SomeSPIGroup) @testable import AnotherModule
 import Implicits
 
 internal import CoreImage

--- a/Sources/TestResources/test_data/support_file_snapshot.swift
+++ b/Sources/TestResources/test_data/support_file_snapshot.swift
@@ -1,7 +1,7 @@
 // swiftformat:disable all
 #if false
 #endif
-import AnotherModule
+@testable @_spi(SomeSPIGroup) import AnotherModule
 private import CoreGraphics
 internal import CoreImage
 import Foundation


### PR DESCRIPTION
`@testable` and `@_spi(group)` on a source import now carry through to the corresponding import in the generated support file. `@_exported` is recognized but intentionally not propagated.

### Changes
- Model imports as `SupportFile.Import` carrying a `Set<ImportAttribute>` instead of bare tuples, and render the attributes back onto the generated imports.
- Consolidate the Swift built-in attribute names the analyzer matches (`testable` / `_exported` / `_spi`) into `ImplicitKeyword.SwiftAttribute` — previously some were hardcoded inline, some went through a constant.
- Gather the scattered `SyntaxTree.Attribute` classification helpers (`simpleIdentifier`, `isImplicit`, `isImplicitSpi`, `isTestable`, `isExported`, `importAttribute`) into a single `SyntaxTreeAttribute.swift`.
- Extend the `test_data` round-trip snapshot to cover the new attributes.

### Test plan
- `swift test` — 121 tests pass, including the updated `support_file` snapshot.