### PR TITLE
Add MacroUtils and ImplicitsShared to IntegrationTests dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -133,7 +133,7 @@ let package = Package(
     ),
     .testTarget(
       name: "IntegrationTests",
-      dependencies: ["Implicits"],
+      dependencies: ["Implicits", "ImplicitsShared", "MacroUtils"],
       swiftSettings: [
         .enableExperimentalFeature("AccessLevelOnImport"),
         .treatAllWarnings(as: .error),


### PR DESCRIPTION
The `#withImplicits` macro used in `WithImplicitsMacroTests` expands to code that references `MacroUtils` and `ImplicitsShared`. The latest Xcode toolchain requires these to be declared as explicit dependencies of the `IntegrationTests` target for it to build.

### Test plan
- `swift test` builds and passes on the latest Xcode.