### PR TITLE
Add release workflow and create-release skill

### DIFF
--- a/.claude/skills/create-release/SKILL.md
+++ b/.claude/skills/create-release/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-release
+description: Cut a new release of the Implicits library — draft categorized release notes from changes since the last tag, create a draft GitHub release, and trigger the Release workflow that tests, tags, and publishes. Use when asked to release implicits, cut/create a release, or via /create-release <version>.
+---
+
+# Create a Release
+
+Creates a release of Implicits. You draft the notes and the draft GitHub
+release; the [`Release` workflow](../../../.github/workflows/release.yml) runs the
+test gate, creates the tag, and publishes. Repo is `yandex/implicits`.
+
+The version comes from the invocation argument (e.g. `/create-release 1.3.0`). If
+none was given, ask for it.
+
+## Preconditions — verify first, abort if any fail
+
+Run and check:
+
+- `git status` — working tree must be clean (no uncommitted changes).
+- `git branch --show-current` and `git rev-parse @{u}` — branch must be up to
+  date with its upstream remote, and `HEAD` must exist on the remote.
+
+If any condition is not met, stop and tell the user what's wrong. **Do not** try
+to commit, push, or otherwise "fix" the tree yourself.
+
+## Process
+
+1. **Validate the version** is SemVer `x.y.z` (no `v` prefix). Reject anything
+   else.
+
+2. **Study recent releases for style.** Run `gh release view <last-tag> --repo
+   yandex/implicits` on the latest one or two (find them with `git tag
+   --sort=-creatordate | head`). Match their conventions:
+   - Plain `###` category headers, **no emoji**. Headers vary by what shipped —
+     e.g. `New Features`, `Bug Fixes`, `Static Analysis`, `Improvements`,
+     `Documentation`, `Tooling`.
+   - Every entry ends with its PR ref `(#NN)`.
+   - Headline features get a **bold name** + an em-dash description.
+   - Add a `Thanks to @… for their contributions!` line when there were external
+     contributors.
+
+3. **Analyze changes since the previous release.** Find the previous tag, then
+   review `git log <prev>..HEAD` and the merged PRs in that range to assemble the
+   entries. Group them under the category headers above.
+
+4. **Write the notes** to a temporary `RELEASE_<version>.md` (use
+   `.claude.local.temp/` so it isn't committed).
+
+5. **Confirm with the user.** Show the drafted notes. If they don't confirm,
+   delete the temp file and stop.
+
+6. **Determine the target branch.** Default `main`. Ask if releasing from another
+   branch (e.g. a hotfix branch).
+
+7. **Create the draft release** (title is the bare version):
+   ```bash
+   gh release create <version> --draft --target <branch> \
+     --title "<version>" --notes-file .claude.local.temp/RELEASE_<version>.md \
+     --repo yandex/implicits
+   ```
+
+8. **Ask** whether to run the release workflow now.
+
+9. **Run the workflow** (if confirmed):
+   ```bash
+   gh workflow run release.yml --repo yandex/implicits
+   ```
+   It validates the draft, runs the full CI gate on the target commit, creates
+   and pushes the tag, and publishes the release. Monitor at
+   https://github.com/yandex/implicits/actions/workflows/release.yml
+
+10. **Clean up** the temporary `RELEASE_<version>.md`.
+
+**Do NOT** manually create the tag or flip the draft to published — the workflow
+handles tagging and publishing. Your job ends at creating the draft and (if
+confirmed) dispatching the workflow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+
+    steps:
+      - name: Find draft release
+        id: find-draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get all releases via API (includes target_commitish)
+          releases=$(gh api repos/${{ github.repository }}/releases)
+
+          # Filter: draft=true, semver tag (x.y.z), no [WIP] in title
+          semver_drafts=$(echo "$releases" | jq '[.[] | select(.draft == true) | select(.tag_name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | select(.name | test("^\\[WIP\\]") | not)]')
+
+          count=$(echo "$semver_drafts" | jq 'length')
+
+          if [ "$count" -eq 0 ]; then
+            echo "No draft release found with semver tag"
+            echo ""
+            echo "Create a draft release first with a tag like '1.3.0'"
+            exit 1
+          fi
+
+          if [ "$count" -gt 1 ]; then
+            echo "Multiple draft releases found with semver tags:"
+            echo "$semver_drafts" | jq -r '.[].tag_name'
+            echo ""
+            echo "Mark other drafts with [WIP] prefix in title to exclude them"
+            exit 1
+          fi
+
+          # Extract release info
+          tag=$(echo "$semver_drafts" | jq -r '.[0].tag_name')
+          target=$(echo "$semver_drafts" | jq -r '.[0].target_commitish')
+
+          # Check if tag already exists via API
+          if gh api repos/${{ github.repository }}/git/refs/tags/$tag --silent 2>/dev/null; then
+            echo "Tag $tag already exists"
+            echo ""
+            echo "Delete the existing tag or use a different version"
+            exit 1
+          fi
+
+          echo "Found draft release: $tag (target: $target)"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+          echo "target=$target" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.find-draft.outputs.target }}
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Build
+        run: swift build -v --enable-experimental-prebuilts
+
+      - name: Run tests
+        run: SWIFT_DETERMINISTIC_HASHING=1 swift test -v --parallel --enable-experimental-prebuilts
+
+      - name: Build Showcase (static analysis)
+        run: swift build --target Showcase --enable-experimental-prebuilts
+
+      - name: Build ShowcaseDependency (static analysis)
+        run: swift build --target ShowcaseDependency --enable-experimental-prebuilts
+
+      - name: Test Implicits for iOS
+        run: swift test --filter ImplicitsTests --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios14.0-simulator --enable-experimental-prebuilts
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.find-draft.outputs.tag }}
+        run: |
+          gh release edit "$VERSION" --repo ${{ github.repository }} --draft=false
+          echo "Published release $VERSION"
+          echo ""
+          echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/$VERSION"


### PR DESCRIPTION
Adds an automated release flow modeled on cggen's.

## What

- **`.github/workflows/release.yml`** — manual `workflow_dispatch` action. Finds the single non-`[WIP]` semver draft release, fails if the tag already exists, checks out the draft's target commit, runs the full CI gate (build, tests, Showcase static-analysis builds, iOS test), pushes the tag, and flips the draft to published. Tag push + publish use the built-in `GITHUB_TOKEN` (`contents: write`) — no secrets to configure.
- **`.claude/skills/create-release/SKILL.md`** — maintainer skill (`/create-release <version>`) that drafts categorized release notes from changes since the last tag, creates the draft GitHub release, and dispatches the workflow. Kept project-local so it does not ship to library consumers via the plugin.

## How to release

1. Write a draft GitHub release: semver tag (no `v`), curated notes, title not `[WIP]`.
2. Actions → Release → Run workflow.

The skill automates steps 1–2.

## Note

After merge, set **Actions → Workflow permissions** to read/write, otherwise the tag push and publish will fail.